### PR TITLE
Fix JS typo in Standalone Dapp Page

### DIFF
--- a/quick-start/dapps/client.md
+++ b/quick-start/dapps/client.md
@@ -137,8 +137,8 @@ connector
 const message = "My email is john@doe.com - 1537836206101"
 
 const msgParams = [
-  convertUtf8ToHex(message)                                                 // Required
-  "0xbc28ea04101f03ea7a94c1379bc3ab32e65e62d3",                             // Required
+  convertUtf8ToHex(message),                                                 // Required
+  "0xbc28ea04101f03ea7a94c1379bc3ab32e65e62d3"                               // Required
 ];
 
 


### PR DESCRIPTION
A comma was misplaced in a code sample. Opening this PR to fix it.