### PR TITLE
Add search to docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -125,6 +125,11 @@ const config = {
         darkTheme: darkCodeTheme,
         additionalLanguages: ['swift','kotlin'],
       },
+      algolia: {
+        appId: 'BH4D9OD16A',
+        apiKey: '4cf6bd4618643027dd526ed4ff272978',
+        indexName: 'walletconnect',
+      },
     }),
 };
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@docusaurus/core": "^2.0.0-beta.7",
     "@docusaurus/preset-classic": "^2.0.0-beta.7",
     "@docusaurus/remark-plugin-npm2yarn": "^2.0.0-beta.7",
+    "@docusaurus/theme-search-algolia": "^2.0.0-beta.7",
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1460,7 +1460,7 @@
     tslib "^2.3.1"
     utility-types "^3.10.0"
 
-"@docusaurus/theme-search-algolia@2.0.0-beta.7":
+"@docusaurus/theme-search-algolia@2.0.0-beta.7", "@docusaurus/theme-search-algolia@^2.0.0-beta.7":
   version "2.0.0-beta.7"
   resolved "https://registry.yarnpkg.com/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.7.tgz#d89e56cb98e3632f0b50a0ff72d34882efabe68b"
   integrity sha512-N/5AVhs/nx1lcHeWG6ek3SjpARJ8UCGyWgcDDb0Li867YFle/b8Slai8ZgKUDrHlRl1+t3iE8G9w5+xAB+FdwA==


### PR DESCRIPTION
This PR adds support for official Docusaurus search provided by Algolia.

https://docusaurus.io/docs/search#using-algolia-docsearch

From Algolia's setup email:

```
Congratulations, your search is now ready! 
I've successfully configured the underlying crawler and it will now run every 24h. 

You're now a few steps away from having it working on your website: 

- Copy the following CSS/JavaScript snippets and add them to your page 

<!-- at the end of the HEAD --> 
<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@alpha" /> 

<!-- at the end of the BODY --> 
<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@docsearch/js@alpha"></script> 
<script type="text/javascript"> 
docsearch({ 
appId: 'BH4D9OD16A', 
apiKey: '4cf6bd4618643027dd526ed4ff272978', 
indexName: 'walletconnect', 
container: '### REPLACE ME ####', 
searchParameters: { 'facetFilters': ["type:$TYPE"] }, 
debug: false // Set debug to true if you want to inspect the modal 
}); 
</script> 

DocSearch is also available on the NPM registry, and for React, learn more on: https://docsearch.algolia.com/docs/DocSearch-v3 

- Add a container in your page if you don't have any yet. Then update the container value in the JavaScript snippet 
to a CSS selector that targets your container or an Element. 

- Replace $TYPE with the type you want to search on. 
The list of possible type is hardcoded in the config. 
So as of today you have: content, lvl1, lvl2, lvl3, lvl4, lvl5 

For example if you want to refine the search to the type "content" just specify: 'facetFilters': ["type:content"] 

- Optionally customize the look and feel by following the DocSearch documentation 
(See https://docsearch.algolia.com/docs/styling/) 
- You can also check your configuration in our GitHub repository 
(See https://github.com/algolia/docsearch-configs/blob/master/configs/walletconnect.json). 
```