### PR TITLE
Use contextual search to support versioned content

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -129,6 +129,7 @@ const config = {
         appId: 'BH4D9OD16A',
         apiKey: '4cf6bd4618643027dd526ed4ff272978',
         indexName: 'walletconnect',
+        contextualSearch: true,
       },
     }),
 };


### PR DESCRIPTION
Our docs site is versioned, with different content for v1 and v2 docs.

![Screenshot 2021-11-01 at 12 21 32 PM](https://user-images.githubusercontent.com/116099/139663960-62b18eaf-8a62-403b-b510-f3c1d0a2b101.png)

Currently, search for terms will show results from both v1 and v2, which can lead a user to out of date content.  For example, here is a search for `bridge` which shows mixed content from v1 and v2.

![Screenshot 2021-11-01 at 12 23 16 PM](https://user-images.githubusercontent.com/116099/139664147-2caa20f4-b2e3-441b-9604-621c043bfa82.png)

This change scopes the results depending on what version is selected.  If v1 is selected, search terms will be scoped to the v1 version.  If v2 is selected (by default), search is scoped to v2.   Scoping the results shows more relevant results from the latest version, rather than showing older or out of date results.

Here is the same query with contextual search added. It only shows mentions of bridge in v2 when searching from default/v2.

![Screenshot 2021-11-01 at 12 25 37 PM](https://user-images.githubusercontent.com/116099/139664354-434f585d-aa1a-4135-b9d9-25fb2e385b67.png)

There is also a search page where the version can be explicitly set.

![Screenshot 2021-11-01 at 12 33 34 PM](https://user-images.githubusercontent.com/116099/139665466-89f300ac-a5fe-483b-b1ef-f47a4da4785d.png)

More details about the setting > https://docusaurus.io/docs/search#contextual-search