### PR TITLE
docs(client): aligns sample code for `Client.init` with v2.0 API

### DIFF
--- a/docs/quick-start/dapps/client.md
+++ b/docs/quick-start/dapps/client.md
@@ -14,13 +14,14 @@ npm install --save @walletconnect/client@experimental
 
 ## Create Session
 
-1. Initiate your WalletConnect client with the relay server
+1. Initiate your WalletConnect client with the relay server, using [your Project ID](../../api/project-id.md).
 
 ```javascript
 import WalletConnectClient from "@walletconnect/client";
 
 const client = await WalletConnectClient.init({
-  relayProvider: "wss://relay.walletconnect.com",
+  projectId: "c4f79cc...",
+  relayUrl: "wss://relay.walletconnect.com",
   metadata: {
     name: "Example Dapp",
     description: "Example Dapp",
@@ -30,7 +31,7 @@ const client = await WalletConnectClient.init({
 });
 ```
 
-1. Subscribe to pairing proposal event for sharing URI
+2. Subscribe to pairing proposal event for sharing URI
 
 ```javascript
 import { CLIENT_EVENTS } from "@walletconnect/client";
@@ -45,7 +46,7 @@ client.on(
 );
 ```
 
-1. Connect application and specify session permissions
+3. Connect application and specify session permissions
 
 ```javascript
 const session = await client.connect({


### PR DESCRIPTION
Aligning the sample code with the options provided by the v2.0 `Client` API: https://github.com/WalletConnect/walletconnect-monorepo/blob/a22bee13df255ee59d338d600175250a3a0ef8aa/packages/types/src/client.ts#L14

* Changes `relayProvider -> relayUrl`
* Adds missing `projectId`
* Fixes step numbering