### PR TITLE
Update algolia search credentials

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -126,8 +126,8 @@ const config = {
         additionalLanguages: ['swift','kotlin'],
       },
       algolia: {
-        appId: 'BH4D9OD16A',
-        apiKey: '4cf6bd4618643027dd526ed4ff272978',
+        appId: 'KEO8ND6AUT',
+        apiKey: '5921626237dc9040afc258af25d4e77d',
         indexName: 'walletconnect',
         contextualSearch: true,
       },


### PR DESCRIPTION
DocSearch, the search service that powers search, has migrated to Algolia.
This PR updates the credentials.

See the Docusaurus blog post for more details https://docusaurus.io/blog/2021/11/21/algolia-docsearch-migration