### PR TITLE
Add solana_signAllTransactions, nonce support, respond with signed transactions

### DIFF
--- a/docs/advanced/rpc-reference/solana-rpc.md
+++ b/docs/advanced/rpc-reference/solana-rpc.md
@@ -94,7 +94,7 @@ This method returns a transaction with added signature by the targetted public k
 		1.5. `signatures` : `Array`, - previous signatures for this instruction set
 			1.5.1. `Object` - signature
 				1.5.1.2. `pubkey` : `String` - pubkey of the signer
-				1.5.1.1. `signature` : `String` - signature matching `pubkey`
+				1.5.1.1. `signature` : `String` - (optional) signature matching `pubkey`
 
 ### Returns
 
@@ -116,7 +116,7 @@ This method returns a transaction with added signature by the targetted public k
 		1.5. `signatures` : `Array`, - previous signatures for this instruction set
 			1.5.1. `Object` - signature
 				1.5.1.2. `pubkey` : `String` - pubkey of the signer
-				1.5.1.1. `signature` : `String` - signature matching `pubkey`
+				1.5.1.1. `signature` : `String` - (optional) signature matching `pubkey`
 
 ### Example
 
@@ -192,7 +192,7 @@ This method returns a an array of transactions with added signatures by the targ
 				1.1.1.5. `signatures` : `Array`, - previous signatures for this instruction set
 					1.1.1.5.1. `Object` - signature
 						1.1.1.5.1.2. `pubkey` : `String` - pubkey of the signer
-						1.1.1.5.1.1. `signature` : `String` - signature matching `pubkey`
+						1.1.1.5.1.1. `signature` : `String` - (optional) signature matching `pubkey`
 
 ### Returns
 
@@ -216,7 +216,7 @@ This method returns a an array of transactions with added signatures by the targ
 				1.1.1.5. `signatures` : `Array`, - previous signatures for this instruction set
 					1.1.1.5.1. `Object` - signature
 						1.1.1.5.1.2. `pubkey` : `String` - pubkey of the signer
-						1.1.1.5.1.1. `signature` : `String` - signature matching `pubkey`
+						1.1.1.5.1.1. `signature` : `String` - (optional) signature matching `pubkey`
 
 ### Example
 

--- a/docs/advanced/rpc-reference/solana-rpc.md
+++ b/docs/advanced/rpc-reference/solana-rpc.md
@@ -78,19 +78,19 @@ This method returns a transaction with added signature by the targetted public k
 
 	1. `Object` - Signing parameters:
 		1.1. `feePayer` : `String` - public key of the transaction fee payer
-		1.2. `instructions` : `Array` - instructions to be atomically executed:
-			1.2.1. `Object` - instruction
-				1.2.1.1. `programId` : `String` - public key of the on chain program
-				1.2.1.2. `data` : `String | undefined` - base58 encoded calldata for instruction
-				1.2.1.3. `keys` : `Array` - account metadata used to define instructions
-					1.2.1.3.1. `Object` - key
-						1.2.1.3.1.1. `isSigner` : `Boolean` - true if an instruction requires a transaction signature matching `pubkey`
-						1.2.1.3.1.2. `isWritable` : `Boolean` - true if the `pubkey` can be loaded as a read-write account
-						1.2.1.3.1.3. `pubkey` : `String` - public key of authorized program
-		1.3. `nonceInfo` : `Object` - (optional) Nonce information. If populated, transaction will use a durable Nonce hash instead of a recentBlockhash.
-			1.3.1	`nonce` : `String` - The current base58 encoded blockhash stored in the nonce
-			1.3.2 `nonceInstruction` : `Object` AdvanceNonceAccount Instruction. See `1.2.1` instruction for layout
-		1.4. `recentBlockhash` : `String` - (optional) a recent blockhash
+		1.2. `recentBlockhash` : `String` - (optional) a recent blockhash
+		1.3. `instructions` : `Array` - instructions to be atomically executed:
+			1.3.1. `Object` - instruction
+				1.3.1.1. `programId` : `String` - public key of the on chain program
+				1.3.1.2. `data` : `String | undefined` - base58 encoded calldata for instruction
+				1.3.1.3. `keys` : `Array` - account metadata used to define instructions
+					1.3.1.3.1. `Object` - key
+						1.3.1.3.1.1. `isSigner` : `Boolean` - true if an instruction requires a transaction signature matching `pubkey`
+						1.3.1.3.1.2. `isWritable` : `Boolean` - true if the `pubkey` can be loaded as a read-write account
+						1.3.1.3.1.3. `pubkey` : `String` - public key of authorized program
+		1.4. `nonceInfo` : `Object` - (optional) Nonce information. If populated, transaction will use a durable Nonce hash instead of a recentBlockhash.
+			1.4.1 `nonce` : `String` - The current base58 encoded blockhash stored in the nonce
+			1.4.2 `nonceInstruction` : `Object` AdvanceNonceAccount Instruction. See `1.3.1` for object layout
 		1.5. `signatures` : `Array`, - (optional) previous signatures for this instruction set
 			1.5.1. `Object` - signature
 				1.5.1.2. `pubkey` : `String` - pubkey of the signer
@@ -100,24 +100,23 @@ This method returns a transaction with added signature by the targetted public k
 
 	1. `Object` - Signed transaction parameters:
 		1.1. `feePayer` : `String` - public key of the transaction fee payer
-		1.2. `instructions` : `Array` - instructions to be atomically executed:
-			1.2.1. `Object` - instruction
-				1.2.1.1. `programId` : `String` - public key of the on chain program
-				1.2.1.2. `data` : `String | undefined` - base58 encoded calldata for instruction
-				1.2.1.3. `keys` : `Array` - account metadata used to define instructions
-					1.2.1.3.1. `Object` - key
-						1.2.1.3.1.1. `isSigner` : `Boolean` - true if an instruction requires a transaction signature matching `pubkey`
-						1.2.1.3.1.2. `isWritable` : `Boolean` - true if the `pubkey` can be loaded as a read-write account
-						1.2.1.3.1.3. `pubkey` : `String` - public key of authorized program
-		1.3. `nonceInfo` : `Object` - (optional) Nonce information. If populated, transaction will use a durable Nonce hash instead of a recentBlockhash.
-			1.3.1	`nonce` : `String` - The current base58 encoded blockhash stored in the nonce
-			1.3.2 `nonceInstruction` : `Object` AdvanceNonceAccount Instruction. See `1.2.1` instruction for layout
-		1.4. `recentBlockhash` : `String` - (optional) a recent blockhash
+		1.2. `recentBlockhash` : `String` - (optional) a recent blockhash
+		1.3. `instructions` : `Array` - instructions to be atomically executed:
+			1.3.1. `Object` - instruction
+				1.3.1.1. `programId` : `String` - public key of the on chain program
+				1.3.1.2. `data` : `String | undefined` - base58 encoded calldata for instruction
+				1.3.1.3. `keys` : `Array` - account metadata used to define instructions
+					1.3.1.3.1. `Object` - key
+						1.3.1.3.1.1. `isSigner` : `Boolean` - true if an instruction requires a transaction signature matching `pubkey`
+						1.3.1.3.1.2. `isWritable` : `Boolean` - true if the `pubkey` can be loaded as a read-write account
+						1.3.1.3.1.3. `pubkey` : `String` - public key of authorized program
+		1.4. `nonceInfo` : `Object` - (optional) Nonce information. If populated, transaction will use a durable Nonce hash instead of a recentBlockhash.
+			1.4.1	`nonce` : `String` - The current base58 encoded blockhash stored in the nonce
+			1.4.2 `nonceInstruction` : `Object` AdvanceNonceAccount Instruction. See `1.3.1` for object layout
 		1.5. `signatures` : `Array`, - (optional) previous signatures for this instruction set
 			1.5.1. `Object` - signature
 				1.5.1.2. `pubkey` : `String` - pubkey of the signer
 				1.5.1.1. `signature` : `String` - signature matching `pubkey`
-		1.6. `signature` : `String` - (deprecated) corresponding signature for signed instructions
 
 ### Example
 
@@ -129,6 +128,7 @@ This method returns a transaction with added signature by the targetted public k
 	"method": "solana_signTransaction",
 	"params": {
 		"feePayer": "AqP3MyNwDP4L1GJKYhzmaAUdrjzpqJUZjahM7kHpgavm",
+		"recentBlockhash": "2bUz6wu3axM8cDDncLB5chWuZaoscSjnoMD2nVvC1swe",
 		"instructions": [{
 			"programId": "Vote111111111111111111111111111111111111111",
 			"data": "37u9WtQpcm6ULa3VtWDFAWoQc1hUvybPrA3dtx99tgHvvcE7pKRZjuGmn7VX2tC3JmYDYGG7",
@@ -137,8 +137,7 @@ This method returns a transaction with added signature by the targetted public k
 				"isWritable": true,
 				"pubkey": "AqP3MyNwDP4L1GJKYhzmaAUdrjzpqJUZjahM7kHpgavm"
 			}]
-		}],
-		"recentBlockhash": "2bUz6wu3axM8cDDncLB5chWuZaoscSjnoMD2nVvC1swe"
+		}]
 	}
 }
 
@@ -148,6 +147,7 @@ This method returns a transaction with added signature by the targetted public k
 	"jsonrpc": "2.0",
 	"result":  {
 		"feePayer": "AqP3MyNwDP4L1GJKYhzmaAUdrjzpqJUZjahM7kHpgavm",
+		"recentBlockhash": "2bUz6wu3axM8cDDncLB5chWuZaoscSjnoMD2nVvC1swe",
 		"instructions": [{
 			"programId": "Vote111111111111111111111111111111111111111",
 			"data": "37u9WtQpcm6ULa3VtWDFAWoQc1hUvybPrA3dtx99tgHvvcE7pKRZjuGmn7VX2tC3JmYDYGG7",
@@ -157,7 +157,6 @@ This method returns a transaction with added signature by the targetted public k
 				"pubkey": "AqP3MyNwDP4L1GJKYhzmaAUdrjzpqJUZjahM7kHpgavm"
 			}]
 		}],
-		"recentBlockhash": "2bUz6wu3axM8cDDncLB5chWuZaoscSjnoMD2nVvC1swe",
 		"signatures": [{
 			"pubkey": "AqP3MyNwDP4L1GJKYhzmaAUdrjzpqJUZjahM7kHpgavm",
 			"signature": "2Lb1KQHWfbV3pWMqXZveFWqneSyhH95YsgCENRWnArSkLydjN1M42oB82zSd6BBdGkM9pE6sQLQf1gyBh8KWM2c4"
@@ -176,19 +175,19 @@ This method returns a an array of transactions with added signatures by the targ
 		1.1 `transactions` : `Array` - array of transactions
 			1.1.1 `Object` - transaction
 				1.1.1.1. `feePayer` : `String` - public key of the transaction fee payer
-				1.1.1.2. `instructions` : `Array` - instructions to be atomically executed:
-					1.1.1.2.1. `Object` - instruction
-						1.1.1.2.1.1. `programId` : `String` - public key of the on chain program
-						1.1.1.2.1.2. `data` : `String | undefined` - base58 encoded calldata for instruction
-						1.1.1.2.1.3. `keys` : `Array` - account metadata used to define instructions
+				1.1.1.2. `recentBlockhash` : `String` - (optional) a recent blockhash
+				1.1.1.3. `instructions` : `Array` - instructions to be atomically executed:
+					1.1.1.3.1. `Object` - instruction
+						1.1.1.3.1.1. `programId` : `String` - public key of the on chain program
+						1.1.1.3.1.2. `data` : `String | undefined` - base58 encoded calldata for instruction
+						1.1.1.3.1.3. `keys` : `Array` - account metadata used to define instructions
 							1.1.1.2.1.3.1. `Object` - key
-								1.1.1.2.1.3.1.1. `isSigner` : `Boolean` - true if an instruction requires a transaction signature matching `pubkey`
-								1.1.1.2.1.3.1.2. `isWritable` : `Boolean` - true if the `pubkey` can be loaded as a read-write account
-								1.1.1.2.1.3.1.3. `pubkey` : `String` - public key of authorized program
-				1.1.1.3. `nonceInfo` : `Object` - (optional) Nonce information. If populated, transaction will use a durable Nonce hash instead of a recentBlockhash.
-					1.1.1.3.1	`nonce` : `String` - The current base58 encoded blockhash stored in the nonce
-					1.1.1.3.2 `nonceInstruction` : `Object` AdvanceNonceAccount Instruction. See `1.2.1` instruction for layout
-				1.1.1.4. `recentBlockhash` : `String` - (optional) a recent blockhash
+								1.1.1.3.1.3.1.1. `isSigner` : `Boolean` - true if an instruction requires a transaction signature matching `pubkey`
+								1.1.1.3.1.3.1.2. `isWritable` : `Boolean` - true if the `pubkey` can be loaded as a read-write account
+								1.1.1.3.1.3.1.3. `pubkey` : `String` - public key of authorized program
+				1.1.1.4. `nonceInfo` : `Object` - (optional) Nonce information. If populated, transaction will use a durable Nonce hash instead of a recentBlockhash.
+					1.1.1.4.1	`nonce` : `String` - The current base58 encoded blockhash stored in the nonce
+					1.1.1.4.2 `nonceInstruction` : `Object` AdvanceNonceAccount Instruction. See `1.1.1.3.1` for object layout
 				1.1.1.5. `signatures` : `Array`, - (optional) previous signatures for this instruction set
 					1.1.1.5.1. `Object` - signature
 						1.1.1.5.1.2. `pubkey` : `String` - pubkey of the signer
@@ -200,19 +199,19 @@ This method returns a an array of transactions with added signatures by the targ
 		1.1 `transactions` : `Array` - array of transactions
 			1.1.1 `Object` - transaction
 				1.1.1.1. `feePayer` : `String` - public key of the transaction fee payer
-				1.1.1.2. `instructions` : `Array` - instructions to be atomically executed:
-					1.1.1.2.1. `Object` - instruction
-						1.1.1.2.1.1. `programId` : `String` - public key of the on chain program
-						1.1.1.2.1.2. `data` : `String | undefined` - base58 encoded calldata for instruction
-						1.1.1.2.1.3. `keys` : `Array` - account metadata used to define instructions
-							1.1.1.2.1.3.1. `Object` - key
-								1.1.1.2.1.3.1.1. `isSigner` : `Boolean` - true if an instruction requires a transaction signature matching `pubkey`
-								1.1.1.2.1.3.1.2. `isWritable` : `Boolean` - true if the `pubkey` can be loaded as a read-write account
-								1.1.1.2.1.3.1.3. `pubkey` : `String` - public key of authorized program
-				1.1.1.3. `nonceInfo` : `Object` - (optional) Nonce information. If populated, transaction will use a durable Nonce hash instead of a recentBlockhash.
-					1.1.1.3.1	`nonce` : `String` - The current base58 encoded blockhash stored in the nonce
-					1.1.1.3.2 `nonceInstruction` : `Object` AdvanceNonceAccount Instruction. See `1.2.1` instruction for layout
-				1.1.1.4. `recentBlockhash` : `String` - (optional) a recent blockhash
+				1.1.1.2. `recentBlockhash` : `String` - (optional) a recent blockhash
+				1.1.1.3. `instructions` : `Array` - instructions to be atomically executed:
+					1.1.1.3.1. `Object` - instruction
+						1.1.1.3.1.1. `programId` : `String` - public key of the on chain program
+						1.1.1.3.1.2. `data` : `String | undefined` - base58 encoded calldata for instruction
+						1.1.1.3.1.3. `keys` : `Array` - account metadata used to define instructions
+							1.1.1.3.1.3.1. `Object` - key
+								1.1.1.3.1.3.1.1. `isSigner` : `Boolean` - true if an instruction requires a transaction signature matching `pubkey`
+								1.1.1.3.1.3.1.2. `isWritable` : `Boolean` - true if the `pubkey` can be loaded as a read-write account
+								1.1.1.3.1.3.1.3. `pubkey` : `String` - public key of authorized program
+				1.1.1.4. `nonceInfo` : `Object` - (optional) Nonce information. If populated, transaction will use a durable Nonce hash instead of a recentBlockhash.
+					1.1.1.4.1 `nonce` : `String` - The current base58 encoded blockhash stored in the nonce
+					1.1.1.4.2 `nonceInstruction` : `Object` AdvanceNonceAccount Instruction. See `1.1.1.3.1` for object layout
 				1.1.1.5. `signatures` : `Array`, - (optional) previous signatures for this instruction set
 					1.1.1.5.1. `Object` - signature
 						1.1.1.5.1.2. `pubkey` : `String` - pubkey of the signer
@@ -225,10 +224,11 @@ This method returns a an array of transactions with added signatures by the targ
 {
 	"id": 1,
 	"jsonrpc": "2.0",
-	"method": "solana_signTransaction",
+	"method": "solana_signAllTransactions",
 	"params": {
 		"transactions": [{
 			"feePayer": "AqP3MyNwDP4L1GJKYhzmaAUdrjzpqJUZjahM7kHpgavm",
+			"recentBlockhash": "2bUz6wu3axM8cDDncLB5chWuZaoscSjnoMD2nVvC1swe",
 			"instructions": [{
 				"programId": "Vote111111111111111111111111111111111111111",
 				"data": "37u9WtQpcm6ULa3VtWDFAWoQc1hUvybPrA3dtx99tgHvvcE7pKRZjuGmn7VX2tC3JmYDYGG7",
@@ -237,8 +237,7 @@ This method returns a an array of transactions with added signatures by the targ
 					"isWritable": true,
 					"pubkey": "AqP3MyNwDP4L1GJKYhzmaAUdrjzpqJUZjahM7kHpgavm"
 				}]
-			}],
-			"recentBlockhash": "2bUz6wu3axM8cDDncLB5chWuZaoscSjnoMD2nVvC1swe"
+			}]
 		}]
 	}
 }
@@ -250,6 +249,7 @@ This method returns a an array of transactions with added signatures by the targ
 	"result":  {
 		"transactions": [{
 			"feePayer": "AqP3MyNwDP4L1GJKYhzmaAUdrjzpqJUZjahM7kHpgavm",
+			"recentBlockhash": "2bUz6wu3axM8cDDncLB5chWuZaoscSjnoMD2nVvC1swe",
 			"instructions": [{
 				"programId": "Vote111111111111111111111111111111111111111",
 				"data": "37u9WtQpcm6ULa3VtWDFAWoQc1hUvybPrA3dtx99tgHvvcE7pKRZjuGmn7VX2tC3JmYDYGG7",
@@ -259,7 +259,6 @@ This method returns a an array of transactions with added signatures by the targ
 					"pubkey": "AqP3MyNwDP4L1GJKYhzmaAUdrjzpqJUZjahM7kHpgavm"
 				}]
 			}],
-			"recentBlockhash": "2bUz6wu3axM8cDDncLB5chWuZaoscSjnoMD2nVvC1swe",
 			"signatures": [{
 				"pubkey": "AqP3MyNwDP4L1GJKYhzmaAUdrjzpqJUZjahM7kHpgavm",
 				"signature": "2Lb1KQHWfbV3pWMqXZveFWqneSyhH95YsgCENRWnArSkLydjN1M42oB82zSd6BBdGkM9pE6sQLQf1gyBh8KWM2c4"

--- a/docs/advanced/rpc-reference/solana-rpc.md
+++ b/docs/advanced/rpc-reference/solana-rpc.md
@@ -91,7 +91,7 @@ This method returns a transaction with added signature by the targetted public k
 		1.4. `nonceInfo` : `Object` - (optional) Nonce information. If populated, transaction will use a durable Nonce hash instead of a recentBlockhash.
 			1.4.1 `nonce` : `String` - The current base58 encoded blockhash stored in the nonce
 			1.4.2 `nonceInstruction` : `Object` AdvanceNonceAccount Instruction. See `1.3.1` for object layout
-		1.5. `signatures` : `Array`, - previous signatures for this instruction set
+		1.5. `signatures` : `Array`, - signatures for this instruction set
 			1.5.1. `Object` - signature
 				1.5.1.2. `pubkey` : `String` - pubkey of the signer
 				1.5.1.1. `signature` : `String` - (optional) signature matching `pubkey`
@@ -113,7 +113,7 @@ This method returns a transaction with added signature by the targetted public k
 		1.4. `nonceInfo` : `Object` - (optional) Nonce information. If populated, transaction will use a durable Nonce hash instead of a recentBlockhash.
 			1.4.1 `nonce` : `String` - The current base58 encoded blockhash stored in the nonce
 			1.4.2 `nonceInstruction` : `Object` AdvanceNonceAccount Instruction. See `1.3.1` for object layout
-		1.5. `signatures` : `Array`, - previous signatures for this instruction set
+		1.5. `signatures` : `Array`, - signatures for this instruction set
 			1.5.1. `Object` - signature
 				1.5.1.2. `pubkey` : `String` - pubkey of the signer
 				1.5.1.1. `signature` : `String` - (optional) signature matching `pubkey`
@@ -189,7 +189,7 @@ This method returns a an array of transactions with added signatures by the targ
 				1.1.1.4. `nonceInfo` : `Object` - (optional) Nonce information. If populated, transaction will use a durable Nonce hash instead of a recentBlockhash.
 					1.1.1.4.1 `nonce` : `String` - The current base58 encoded blockhash stored in the nonce
 					1.1.1.4.2 `nonceInstruction` : `Object` AdvanceNonceAccount Instruction. See `1.1.1.3.1` for object layout
-				1.1.1.5. `signatures` : `Array`, - previous signatures for this instruction set
+				1.1.1.5. `signatures` : `Array`, - signatures for this instruction set
 					1.1.1.5.1. `Object` - signature
 						1.1.1.5.1.2. `pubkey` : `String` - pubkey of the signer
 						1.1.1.5.1.1. `signature` : `String` - (optional) signature matching `pubkey`
@@ -213,7 +213,7 @@ This method returns a an array of transactions with added signatures by the targ
 				1.1.1.4. `nonceInfo` : `Object` - (optional) Nonce information. If populated, transaction will use a durable Nonce hash instead of a recentBlockhash.
 					1.1.1.4.1 `nonce` : `String` - The current base58 encoded blockhash stored in the nonce
 					1.1.1.4.2 `nonceInstruction` : `Object` AdvanceNonceAccount Instruction. See `1.1.1.3.1` for object layout
-				1.1.1.5. `signatures` : `Array`, - previous signatures for this instruction set
+				1.1.1.5. `signatures` : `Array`, - signatures for this instruction set
 					1.1.1.5.1. `Object` - signature
 						1.1.1.5.1.2. `pubkey` : `String` - pubkey of the signer
 						1.1.1.5.1.1. `signature` : `String` - (optional) signature matching `pubkey`

--- a/docs/advanced/rpc-reference/solana-rpc.md
+++ b/docs/advanced/rpc-reference/solana-rpc.md
@@ -10,13 +10,13 @@ This method returns an Array of public keys available to sign from the wallet.
 
 ### Parameters
 
-    none
+	none
 
 ### Returns
 
-    1.`Array` - Array of accounts:
-    	1.1. `Object`
-    		1.1.1. `pubkey` : `String` - public key for keypair
+	1.`Array` - Array of accounts:
+		1.1. `Object`
+			1.1.1. `pubkey` : `String` - public key for keypair
 
 ### Example
 
@@ -43,13 +43,13 @@ This method returns an Array of public keys available to sign from the wallet.
 
 ### Parameters
 
-    none
+	none
 
 ### Returns
 
-    1.`Array` - Array of accounts:
-    	1.1. `Object`
-    		1.1.1. `pubkey` : `String` - public key for keypair
+	1.`Array` - Array of accounts:
+		1.1. `Object`
+			1.1.1. `pubkey` : `String` - public key for keypair
 
 ### Example
 
@@ -76,48 +76,48 @@ This method returns a transaction with added signature by the targetted public k
 
 ### Parameters
 
-    1. `Object` - Signing parameters:
-    	1.1. `feePayer` : `String` - public key of the transaction fee payer
-    	1.2. `instructions` : `Array` - instructions to be atomically executed:
-    		1.2.1. `Object` - instruction
-    			1.2.1.1. `programId` : `String` - public key of the on chain program
-    			1.2.1.2. `data` : `String | undefined` - base58 encoded calldata for instruction
-    			1.2.1.3. `keys` : `Array` - account metadata used to define instructions
-    				1.2.1.3.1. `Object` - key
-    					1.2.1.3.1.1. `isSigner` : `Boolean` - true if an instruction requires a transaction signature matching `pubkey`
-    					1.2.1.3.1.2. `isWritable` : `Boolean` - true if the `pubkey` can be loaded as a read-write account
-    					1.2.1.3.1.3. `pubkey` : `String` - public key of authorized program
-			1.3. `nonceInfo` : `Object` - (optional) Nonce information. If populated, transaction will use a durable Nonce hash instead of a recentBlockhash.
-				1.3.1	`nonce` : `String` - The current base58 encoded blockhash stored in the nonce
-				1.3.2 `nonceInstruction` : `Object` AdvanceNonceAccount Instruction. See `1.2.1` instruction for layout
-    	1.4. `recentBlockhash` : `String` - (optional) a recent blockhash
-    	1.5. `signatures` : `Array`, - (optional) previous signatures for this instruction set
-    		1.5.1. `Object` - signature
-    			1.5.1.2. `pubkey` : `String` - pubkey of the signer
-    			1.5.1.1. `signature` : `String` - signature matching `pubkey`
+	1. `Object` - Signing parameters:
+		1.1. `feePayer` : `String` - public key of the transaction fee payer
+		1.2. `instructions` : `Array` - instructions to be atomically executed:
+			1.2.1. `Object` - instruction
+				1.2.1.1. `programId` : `String` - public key of the on chain program
+				1.2.1.2. `data` : `String | undefined` - base58 encoded calldata for instruction
+				1.2.1.3. `keys` : `Array` - account metadata used to define instructions
+					1.2.1.3.1. `Object` - key
+						1.2.1.3.1.1. `isSigner` : `Boolean` - true if an instruction requires a transaction signature matching `pubkey`
+						1.2.1.3.1.2. `isWritable` : `Boolean` - true if the `pubkey` can be loaded as a read-write account
+						1.2.1.3.1.3. `pubkey` : `String` - public key of authorized program
+		1.3. `nonceInfo` : `Object` - (optional) Nonce information. If populated, transaction will use a durable Nonce hash instead of a recentBlockhash.
+			1.3.1	`nonce` : `String` - The current base58 encoded blockhash stored in the nonce
+			1.3.2 `nonceInstruction` : `Object` AdvanceNonceAccount Instruction. See `1.2.1` instruction for layout
+		1.4. `recentBlockhash` : `String` - (optional) a recent blockhash
+		1.5. `signatures` : `Array`, - (optional) previous signatures for this instruction set
+			1.5.1. `Object` - signature
+				1.5.1.2. `pubkey` : `String` - pubkey of the signer
+				1.5.1.1. `signature` : `String` - signature matching `pubkey`
 
 ### Returns
 
-    1. `Object` - Signed transaction parameters:
-    	1.1. `feePayer` : `String` - public key of the transaction fee payer
-    	1.2. `instructions` : `Array` - instructions to be atomically executed:
-    		1.2.1. `Object` - instruction
-    			1.2.1.1. `programId` : `String` - public key of the on chain program
-    			1.2.1.2. `data` : `String | undefined` - base58 encoded calldata for instruction
-    			1.2.1.3. `keys` : `Array` - account metadata used to define instructions
-    				1.2.1.3.1. `Object` - key
-    					1.2.1.3.1.1. `isSigner` : `Boolean` - true if an instruction requires a transaction signature matching `pubkey`
-    					1.2.1.3.1.2. `isWritable` : `Boolean` - true if the `pubkey` can be loaded as a read-write account
-    					1.2.1.3.1.3. `pubkey` : `String` - public key of authorized program
-			1.3. `nonceInfo` : `Object` - (optional) Nonce information. If populated, transaction will use a durable Nonce hash instead of a recentBlockhash.
-				1.3.1	`nonce` : `String` - The current base58 encoded blockhash stored in the nonce
-				1.3.2 `nonceInstruction` : `Object` AdvanceNonceAccount Instruction. See `1.2.1` instruction for layout
-    	1.4. `recentBlockhash` : `String` - (optional) a recent blockhash
-    	1.5. `signatures` : `Array`, - (optional) previous signatures for this instruction set
-    		1.5.1. `Object` - signature
-    			1.5.1.2. `pubkey` : `String` - pubkey of the signer
-    			1.5.1.1. `signature` : `String` - signature matching `pubkey`
-    	1.6. `signature` : `String` - (deprecated) corresponding signature for signed instructions
+	1. `Object` - Signed transaction parameters:
+		1.1. `feePayer` : `String` - public key of the transaction fee payer
+		1.2. `instructions` : `Array` - instructions to be atomically executed:
+			1.2.1. `Object` - instruction
+				1.2.1.1. `programId` : `String` - public key of the on chain program
+				1.2.1.2. `data` : `String | undefined` - base58 encoded calldata for instruction
+				1.2.1.3. `keys` : `Array` - account metadata used to define instructions
+					1.2.1.3.1. `Object` - key
+						1.2.1.3.1.1. `isSigner` : `Boolean` - true if an instruction requires a transaction signature matching `pubkey`
+						1.2.1.3.1.2. `isWritable` : `Boolean` - true if the `pubkey` can be loaded as a read-write account
+						1.2.1.3.1.3. `pubkey` : `String` - public key of authorized program
+		1.3. `nonceInfo` : `Object` - (optional) Nonce information. If populated, transaction will use a durable Nonce hash instead of a recentBlockhash.
+			1.3.1	`nonce` : `String` - The current base58 encoded blockhash stored in the nonce
+			1.3.2 `nonceInstruction` : `Object` AdvanceNonceAccount Instruction. See `1.2.1` instruction for layout
+		1.4. `recentBlockhash` : `String` - (optional) a recent blockhash
+		1.5. `signatures` : `Array`, - (optional) previous signatures for this instruction set
+			1.5.1. `Object` - signature
+				1.5.1.2. `pubkey` : `String` - pubkey of the signer
+				1.5.1.1. `signature` : `String` - signature matching `pubkey`
+		1.6. `signature` : `String` - (deprecated) corresponding signature for signed instructions
 
 ### Example
 
@@ -172,51 +172,51 @@ This method returns a an array of transactions with added signatures by the targ
 
 ### Parameters
 
-    1. `Object` - Signing transaction array parameters:
-			1.1 `transactions` : `Array` - array of transactions
-				1.1.1 `Object` - transaction
-					1.1.1.1. `feePayer` : `String` - public key of the transaction fee payer
-					1.1.1.2. `instructions` : `Array` - instructions to be atomically executed:
-						1.1.1.2.1. `Object` - instruction
-							1.1.1.2.1.1. `programId` : `String` - public key of the on chain program
-							1.1.1.2.1.2. `data` : `String | undefined` - base58 encoded calldata for instruction
-							1.1.1.2.1.3. `keys` : `Array` - account metadata used to define instructions
-								1.1.1.2.1.3.1. `Object` - key
-									1.1.1.2.1.3.1.1. `isSigner` : `Boolean` - true if an instruction requires a transaction signature matching `pubkey`
-									1.1.1.2.1.3.1.2. `isWritable` : `Boolean` - true if the `pubkey` can be loaded as a read-write account
-									1.1.1.2.1.3.1.3. `pubkey` : `String` - public key of authorized program
-					1.1.1.3. `nonceInfo` : `Object` - (optional) Nonce information. If populated, transaction will use a durable Nonce hash instead of a recentBlockhash.
-						1.1.1.3.1	`nonce` : `String` - The current base58 encoded blockhash stored in the nonce
-						1.1.1.3.2 `nonceInstruction` : `Object` AdvanceNonceAccount Instruction. See `1.2.1` instruction for layout
-					1.1.1.4. `recentBlockhash` : `String` - (optional) a recent blockhash
-					1.1.1.5. `signatures` : `Array`, - (optional) previous signatures for this instruction set
-						1.1.1.5.1. `Object` - signature
-							1.1.1.5.1.2. `pubkey` : `String` - pubkey of the signer
-							1.1.1.5.1.1. `signature` : `String` - signature matching `pubkey`
+	1. `Object` - Signing transaction array parameters:
+		1.1 `transactions` : `Array` - array of transactions
+			1.1.1 `Object` - transaction
+				1.1.1.1. `feePayer` : `String` - public key of the transaction fee payer
+				1.1.1.2. `instructions` : `Array` - instructions to be atomically executed:
+					1.1.1.2.1. `Object` - instruction
+						1.1.1.2.1.1. `programId` : `String` - public key of the on chain program
+						1.1.1.2.1.2. `data` : `String | undefined` - base58 encoded calldata for instruction
+						1.1.1.2.1.3. `keys` : `Array` - account metadata used to define instructions
+							1.1.1.2.1.3.1. `Object` - key
+								1.1.1.2.1.3.1.1. `isSigner` : `Boolean` - true if an instruction requires a transaction signature matching `pubkey`
+								1.1.1.2.1.3.1.2. `isWritable` : `Boolean` - true if the `pubkey` can be loaded as a read-write account
+								1.1.1.2.1.3.1.3. `pubkey` : `String` - public key of authorized program
+				1.1.1.3. `nonceInfo` : `Object` - (optional) Nonce information. If populated, transaction will use a durable Nonce hash instead of a recentBlockhash.
+					1.1.1.3.1	`nonce` : `String` - The current base58 encoded blockhash stored in the nonce
+					1.1.1.3.2 `nonceInstruction` : `Object` AdvanceNonceAccount Instruction. See `1.2.1` instruction for layout
+				1.1.1.4. `recentBlockhash` : `String` - (optional) a recent blockhash
+				1.1.1.5. `signatures` : `Array`, - (optional) previous signatures for this instruction set
+					1.1.1.5.1. `Object` - signature
+						1.1.1.5.1.2. `pubkey` : `String` - pubkey of the signer
+						1.1.1.5.1.1. `signature` : `String` - signature matching `pubkey`
 
 ### Returns
 
-    1. `Object` - Signed transaction array parameters:
-			1.1 `transactions` : `Array` - array of transactions
-				1.1.1 `Object` - transaction
-					1.1.1.1. `feePayer` : `String` - public key of the transaction fee payer
-					1.1.1.2. `instructions` : `Array` - instructions to be atomically executed:
-						1.1.1.2.1. `Object` - instruction
-							1.1.1.2.1.1. `programId` : `String` - public key of the on chain program
-							1.1.1.2.1.2. `data` : `String | undefined` - base58 encoded calldata for instruction
-							1.1.1.2.1.3. `keys` : `Array` - account metadata used to define instructions
-								1.1.1.2.1.3.1. `Object` - key
-									1.1.1.2.1.3.1.1. `isSigner` : `Boolean` - true if an instruction requires a transaction signature matching `pubkey`
-									1.1.1.2.1.3.1.2. `isWritable` : `Boolean` - true if the `pubkey` can be loaded as a read-write account
-									1.1.1.2.1.3.1.3. `pubkey` : `String` - public key of authorized program
-					1.1.1.3. `nonceInfo` : `Object` - (optional) Nonce information. If populated, transaction will use a durable Nonce hash instead of a recentBlockhash.
-						1.1.1.3.1	`nonce` : `String` - The current base58 encoded blockhash stored in the nonce
-						1.1.1.3.2 `nonceInstruction` : `Object` AdvanceNonceAccount Instruction. See `1.2.1` instruction for layout
-					1.1.1.4. `recentBlockhash` : `String` - (optional) a recent blockhash
-					1.1.1.5. `signatures` : `Array`, - (optional) previous signatures for this instruction set
-						1.1.1.5.1. `Object` - signature
-							1.1.1.5.1.2. `pubkey` : `String` - pubkey of the signer
-							1.1.1.5.1.1. `signature` : `String` - signature matching `pubkey`
+	1. `Object` - Signed transaction array parameters:
+		1.1 `transactions` : `Array` - array of transactions
+			1.1.1 `Object` - transaction
+				1.1.1.1. `feePayer` : `String` - public key of the transaction fee payer
+				1.1.1.2. `instructions` : `Array` - instructions to be atomically executed:
+					1.1.1.2.1. `Object` - instruction
+						1.1.1.2.1.1. `programId` : `String` - public key of the on chain program
+						1.1.1.2.1.2. `data` : `String | undefined` - base58 encoded calldata for instruction
+						1.1.1.2.1.3. `keys` : `Array` - account metadata used to define instructions
+							1.1.1.2.1.3.1. `Object` - key
+								1.1.1.2.1.3.1.1. `isSigner` : `Boolean` - true if an instruction requires a transaction signature matching `pubkey`
+								1.1.1.2.1.3.1.2. `isWritable` : `Boolean` - true if the `pubkey` can be loaded as a read-write account
+								1.1.1.2.1.3.1.3. `pubkey` : `String` - public key of authorized program
+				1.1.1.3. `nonceInfo` : `Object` - (optional) Nonce information. If populated, transaction will use a durable Nonce hash instead of a recentBlockhash.
+					1.1.1.3.1	`nonce` : `String` - The current base58 encoded blockhash stored in the nonce
+					1.1.1.3.2 `nonceInstruction` : `Object` AdvanceNonceAccount Instruction. See `1.2.1` instruction for layout
+				1.1.1.4. `recentBlockhash` : `String` - (optional) a recent blockhash
+				1.1.1.5. `signatures` : `Array`, - (optional) previous signatures for this instruction set
+					1.1.1.5.1. `Object` - signature
+						1.1.1.5.1.2. `pubkey` : `String` - pubkey of the signer
+						1.1.1.5.1.1. `signature` : `String` - signature matching `pubkey`
 
 ### Example
 
@@ -275,14 +275,14 @@ This method returns a signature for the provided message from the requested sign
 
 ### Parameters
 
-    1. `Object` - Signing parameters:
-    	1.1. `message` : `String` -  the message to be signed (base58 encoded)
-    	1.2. `pubkey` : `String` -  public key of the signer
+	1. `Object` - Signing parameters:
+		1.1. `message` : `String` -  the message to be signed (base58 encoded)
+		1.2. `pubkey` : `String` -  public key of the signer
 
 ### Returns
 
-    1. `Object`
-    	1.1. `signature` : `String` - corresponding signature for signed message
+	1. `Object`
+		1.1. `signature` : `String` - corresponding signature for signed message
 
 ### Example
 

--- a/docs/advanced/rpc-reference/solana-rpc.md
+++ b/docs/advanced/rpc-reference/solana-rpc.md
@@ -72,31 +72,52 @@ This method returns an Array of public keys available to sign from the wallet.
 
 ## solana_signTransaction
 
-This method returns a signature over the provided instuctions by the targetted public key.
+This method returns a transaction with added signature by the targetted public key over the provided transaction.
 
 ### Parameters
 
     1. `Object` - Signing parameters:
-    	1.1. `feePayer` : `String` -  public key of the transaction fee payer
+    	1.1. `feePayer` : `String` - public key of the transaction fee payer
     	1.2. `instructions` : `Array` - instructions to be atomically executed:
     		1.2.1. `Object` - instruction
     			1.2.1.1. `programId` : `String` - public key of the on chain program
-    			1.2.1.2. `data` : `String | undefined` - encoded calldata for instruction
+    			1.2.1.2. `data` : `String | undefined` - base58 encoded calldata for instruction
     			1.2.1.3. `keys` : `Array` - account metadata used to define instructions
     				1.2.1.3.1. `Object` - key
     					1.2.1.3.1.1. `isSigner` : `Boolean` - true if an instruction requires a transaction signature matching `pubkey`
     					1.2.1.3.1.2. `isWritable` : `Boolean` - true if the `pubkey` can be loaded as a read-write account
     					1.2.1.3.1.3. `pubkey` : `String` - public key of authorized program
-    	1.3. `recentBlockhash` : `String` - a recent blockhash
-    	1.4. `partialSignatures` : `Array`, - (optional) previous partial signatures for this instruction set
-    		1.4.1. `Object` - partial signature
-    			1.4.1.2. `pubkey` : `String` - pubkey of the signer
-    			1.4.1.1. `signature` : `String` - signature matching `pubkey`
+			1.3. `nonceInfo` : `Object` - (optional) Nonce information. If populated, transaction will use a durable Nonce hash instead of a recentBlockhash.
+				1.3.1	`nonce` : `String` - The current base58 encoded blockhash stored in the nonce
+				1.3.2 `nonceInstruction` : `Object` AdvanceNonceAccount Instruction. See `1.2.1` instruction for layout
+    	1.4. `recentBlockhash` : `String` - (optional) a recent blockhash
+    	1.5. `signatures` : `Array`, - (optional) previous signatures for this instruction set
+    		1.5.1. `Object` - signature
+    			1.5.1.2. `pubkey` : `String` - pubkey of the signer
+    			1.5.1.1. `signature` : `String` - signature matching `pubkey`
 
 ### Returns
 
-    1. `Object`
-    	1.1. `signature` : `String` - corresponding signature for signed instructions
+    1. `Object` - Signed transaction parameters:
+    	1.1. `feePayer` : `String` - public key of the transaction fee payer
+    	1.2. `instructions` : `Array` - instructions to be atomically executed:
+    		1.2.1. `Object` - instruction
+    			1.2.1.1. `programId` : `String` - public key of the on chain program
+    			1.2.1.2. `data` : `String | undefined` - base58 encoded calldata for instruction
+    			1.2.1.3. `keys` : `Array` - account metadata used to define instructions
+    				1.2.1.3.1. `Object` - key
+    					1.2.1.3.1.1. `isSigner` : `Boolean` - true if an instruction requires a transaction signature matching `pubkey`
+    					1.2.1.3.1.2. `isWritable` : `Boolean` - true if the `pubkey` can be loaded as a read-write account
+    					1.2.1.3.1.3. `pubkey` : `String` - public key of authorized program
+			1.3. `nonceInfo` : `Object` - (optional) Nonce information. If populated, transaction will use a durable Nonce hash instead of a recentBlockhash.
+				1.3.1	`nonce` : `String` - The current base58 encoded blockhash stored in the nonce
+				1.3.2 `nonceInstruction` : `Object` AdvanceNonceAccount Instruction. See `1.2.1` instruction for layout
+    	1.4. `recentBlockhash` : `String` - (optional) a recent blockhash
+    	1.5. `signatures` : `Array`, - (optional) previous signatures for this instruction set
+    		1.5.1. `Object` - signature
+    			1.5.1.2. `pubkey` : `String` - pubkey of the signer
+    			1.5.1.1. `signature` : `String` - signature matching `pubkey`
+    	1.6. `signature` : `String` - (deprecated) corresponding signature for signed instructions
 
 ### Example
 
@@ -117,10 +138,107 @@ This method returns a signature over the provided instuctions by the targetted p
 				"pubkey": "AqP3MyNwDP4L1GJKYhzmaAUdrjzpqJUZjahM7kHpgavm"
 			}]
 		}],
+		"recentBlockhash": "2bUz6wu3axM8cDDncLB5chWuZaoscSjnoMD2nVvC1swe"
+	}
+}
+
+// Result
+{
+	"id": 1,
+	"jsonrpc": "2.0",
+	"result":  {
+		"feePayer": "AqP3MyNwDP4L1GJKYhzmaAUdrjzpqJUZjahM7kHpgavm",
+		"instructions": [{
+			"programId": "Vote111111111111111111111111111111111111111",
+			"data": "37u9WtQpcm6ULa3VtWDFAWoQc1hUvybPrA3dtx99tgHvvcE7pKRZjuGmn7VX2tC3JmYDYGG7",
+			"keys": [{
+				"isSigner": true,
+				"isWritable": true,
+				"pubkey": "AqP3MyNwDP4L1GJKYhzmaAUdrjzpqJUZjahM7kHpgavm"
+			}]
+		}],
 		"recentBlockhash": "2bUz6wu3axM8cDDncLB5chWuZaoscSjnoMD2nVvC1swe",
 		"signatures": [{
 			"pubkey": "AqP3MyNwDP4L1GJKYhzmaAUdrjzpqJUZjahM7kHpgavm",
 			"signature": "2Lb1KQHWfbV3pWMqXZveFWqneSyhH95YsgCENRWnArSkLydjN1M42oB82zSd6BBdGkM9pE6sQLQf1gyBh8KWM2c4"
+		}]
+	}
+}
+```
+
+## solana_signAllTransactions
+
+This method returns a an array of transactions with added signatures by the targetted public key for the provided transactions.
+
+### Parameters
+
+    1. `Object` - Signing transaction array parameters:
+			1.1 `transactions` : `Array` - array of transactions
+				1.1.1 `Object` - transaction
+					1.1.1.1. `feePayer` : `String` - public key of the transaction fee payer
+					1.1.1.2. `instructions` : `Array` - instructions to be atomically executed:
+						1.1.1.2.1. `Object` - instruction
+							1.1.1.2.1.1. `programId` : `String` - public key of the on chain program
+							1.1.1.2.1.2. `data` : `String | undefined` - base58 encoded calldata for instruction
+							1.1.1.2.1.3. `keys` : `Array` - account metadata used to define instructions
+								1.1.1.2.1.3.1. `Object` - key
+									1.1.1.2.1.3.1.1. `isSigner` : `Boolean` - true if an instruction requires a transaction signature matching `pubkey`
+									1.1.1.2.1.3.1.2. `isWritable` : `Boolean` - true if the `pubkey` can be loaded as a read-write account
+									1.1.1.2.1.3.1.3. `pubkey` : `String` - public key of authorized program
+					1.1.1.3. `nonceInfo` : `Object` - (optional) Nonce information. If populated, transaction will use a durable Nonce hash instead of a recentBlockhash.
+						1.1.1.3.1	`nonce` : `String` - The current base58 encoded blockhash stored in the nonce
+						1.1.1.3.2 `nonceInstruction` : `Object` AdvanceNonceAccount Instruction. See `1.2.1` instruction for layout
+					1.1.1.4. `recentBlockhash` : `String` - (optional) a recent blockhash
+					1.1.1.5. `signatures` : `Array`, - (optional) previous signatures for this instruction set
+						1.1.1.5.1. `Object` - signature
+							1.1.1.5.1.2. `pubkey` : `String` - pubkey of the signer
+							1.1.1.5.1.1. `signature` : `String` - signature matching `pubkey`
+
+### Returns
+
+    1. `Object` - Signed transaction array parameters:
+			1.1 `transactions` : `Array` - array of transactions
+				1.1.1 `Object` - transaction
+					1.1.1.1. `feePayer` : `String` - public key of the transaction fee payer
+					1.1.1.2. `instructions` : `Array` - instructions to be atomically executed:
+						1.1.1.2.1. `Object` - instruction
+							1.1.1.2.1.1. `programId` : `String` - public key of the on chain program
+							1.1.1.2.1.2. `data` : `String | undefined` - base58 encoded calldata for instruction
+							1.1.1.2.1.3. `keys` : `Array` - account metadata used to define instructions
+								1.1.1.2.1.3.1. `Object` - key
+									1.1.1.2.1.3.1.1. `isSigner` : `Boolean` - true if an instruction requires a transaction signature matching `pubkey`
+									1.1.1.2.1.3.1.2. `isWritable` : `Boolean` - true if the `pubkey` can be loaded as a read-write account
+									1.1.1.2.1.3.1.3. `pubkey` : `String` - public key of authorized program
+					1.1.1.3. `nonceInfo` : `Object` - (optional) Nonce information. If populated, transaction will use a durable Nonce hash instead of a recentBlockhash.
+						1.1.1.3.1	`nonce` : `String` - The current base58 encoded blockhash stored in the nonce
+						1.1.1.3.2 `nonceInstruction` : `Object` AdvanceNonceAccount Instruction. See `1.2.1` instruction for layout
+					1.1.1.4. `recentBlockhash` : `String` - (optional) a recent blockhash
+					1.1.1.5. `signatures` : `Array`, - (optional) previous signatures for this instruction set
+						1.1.1.5.1. `Object` - signature
+							1.1.1.5.1.2. `pubkey` : `String` - pubkey of the signer
+							1.1.1.5.1.1. `signature` : `String` - signature matching `pubkey`
+
+### Example
+
+```javascript
+// Request
+{
+	"id": 1,
+	"jsonrpc": "2.0",
+	"method": "solana_signTransaction",
+	"params": {
+		"transactions": [{
+			"feePayer": "AqP3MyNwDP4L1GJKYhzmaAUdrjzpqJUZjahM7kHpgavm",
+			"instructions": [{
+				"programId": "Vote111111111111111111111111111111111111111",
+				"data": "37u9WtQpcm6ULa3VtWDFAWoQc1hUvybPrA3dtx99tgHvvcE7pKRZjuGmn7VX2tC3JmYDYGG7",
+				"keys": [{
+					"isSigner": true,
+					"isWritable": true,
+					"pubkey": "AqP3MyNwDP4L1GJKYhzmaAUdrjzpqJUZjahM7kHpgavm"
+				}]
+			}],
+			"recentBlockhash": "2bUz6wu3axM8cDDncLB5chWuZaoscSjnoMD2nVvC1swe"
 		}]
 	}
 }
@@ -129,7 +247,25 @@ This method returns a signature over the provided instuctions by the targetted p
 {
 	"id": 1,
 	"jsonrpc": "2.0",
-	"result":  { signature: "2Lb1KQHWfbV3pWMqXZveFWqneSyhH95YsgCENRWnArSkLydjN1M42oB82zSd6BBdGkM9pE6sQLQf1gyBh8KWM2c4" }
+	"result":  {
+		"transactions": [{
+			"feePayer": "AqP3MyNwDP4L1GJKYhzmaAUdrjzpqJUZjahM7kHpgavm",
+			"instructions": [{
+				"programId": "Vote111111111111111111111111111111111111111",
+				"data": "37u9WtQpcm6ULa3VtWDFAWoQc1hUvybPrA3dtx99tgHvvcE7pKRZjuGmn7VX2tC3JmYDYGG7",
+				"keys": [{
+					"isSigner": true,
+					"isWritable": true,
+					"pubkey": "AqP3MyNwDP4L1GJKYhzmaAUdrjzpqJUZjahM7kHpgavm"
+				}]
+			}],
+			"recentBlockhash": "2bUz6wu3axM8cDDncLB5chWuZaoscSjnoMD2nVvC1swe",
+			"signatures": [{
+				"pubkey": "AqP3MyNwDP4L1GJKYhzmaAUdrjzpqJUZjahM7kHpgavm",
+				"signature": "2Lb1KQHWfbV3pWMqXZveFWqneSyhH95YsgCENRWnArSkLydjN1M42oB82zSd6BBdGkM9pE6sQLQf1gyBh8KWM2c4"
+			}]
+		}]
+	}
 }
 ```
 

--- a/docs/advanced/rpc-reference/solana-rpc.md
+++ b/docs/advanced/rpc-reference/solana-rpc.md
@@ -82,7 +82,7 @@ This method returns a transaction with added signature by the targetted public k
 		1.3. `instructions` : `Array` - instructions to be atomically executed:
 			1.3.1. `Object` - instruction
 				1.3.1.1. `programId` : `String` - public key of the on chain program
-				1.3.1.2. `data` : `String | undefined` - base58 encoded calldata for instruction
+				1.3.1.2. `data` : `String` - base58 encoded calldata for instruction
 				1.3.1.3. `keys` : `Array` - account metadata used to define instructions
 					1.3.1.3.1. `Object` - key
 						1.3.1.3.1.1. `isSigner` : `Boolean` - true if an instruction requires a transaction signature matching `pubkey`
@@ -91,7 +91,7 @@ This method returns a transaction with added signature by the targetted public k
 		1.4. `nonceInfo` : `Object` - (optional) Nonce information. If populated, transaction will use a durable Nonce hash instead of a recentBlockhash.
 			1.4.1 `nonce` : `String` - The current base58 encoded blockhash stored in the nonce
 			1.4.2 `nonceInstruction` : `Object` AdvanceNonceAccount Instruction. See `1.3.1` for object layout
-		1.5. `signatures` : `Array`, - (optional) previous signatures for this instruction set
+		1.5. `signatures` : `Array`, - previous signatures for this instruction set
 			1.5.1. `Object` - signature
 				1.5.1.2. `pubkey` : `String` - pubkey of the signer
 				1.5.1.1. `signature` : `String` - signature matching `pubkey`
@@ -104,16 +104,16 @@ This method returns a transaction with added signature by the targetted public k
 		1.3. `instructions` : `Array` - instructions to be atomically executed:
 			1.3.1. `Object` - instruction
 				1.3.1.1. `programId` : `String` - public key of the on chain program
-				1.3.1.2. `data` : `String | undefined` - base58 encoded calldata for instruction
+				1.3.1.2. `data` : `String` - base58 encoded calldata for instruction
 				1.3.1.3. `keys` : `Array` - account metadata used to define instructions
 					1.3.1.3.1. `Object` - key
 						1.3.1.3.1.1. `isSigner` : `Boolean` - true if an instruction requires a transaction signature matching `pubkey`
 						1.3.1.3.1.2. `isWritable` : `Boolean` - true if the `pubkey` can be loaded as a read-write account
 						1.3.1.3.1.3. `pubkey` : `String` - public key of authorized program
 		1.4. `nonceInfo` : `Object` - (optional) Nonce information. If populated, transaction will use a durable Nonce hash instead of a recentBlockhash.
-			1.4.1	`nonce` : `String` - The current base58 encoded blockhash stored in the nonce
+			1.4.1 `nonce` : `String` - The current base58 encoded blockhash stored in the nonce
 			1.4.2 `nonceInstruction` : `Object` AdvanceNonceAccount Instruction. See `1.3.1` for object layout
-		1.5. `signatures` : `Array`, - (optional) previous signatures for this instruction set
+		1.5. `signatures` : `Array`, - previous signatures for this instruction set
 			1.5.1. `Object` - signature
 				1.5.1.2. `pubkey` : `String` - pubkey of the signer
 				1.5.1.1. `signature` : `String` - signature matching `pubkey`
@@ -137,7 +137,8 @@ This method returns a transaction with added signature by the targetted public k
 				"isWritable": true,
 				"pubkey": "AqP3MyNwDP4L1GJKYhzmaAUdrjzpqJUZjahM7kHpgavm"
 			}]
-		}]
+		}],
+		"signatures": []
 	}
 }
 
@@ -179,16 +180,16 @@ This method returns a an array of transactions with added signatures by the targ
 				1.1.1.3. `instructions` : `Array` - instructions to be atomically executed:
 					1.1.1.3.1. `Object` - instruction
 						1.1.1.3.1.1. `programId` : `String` - public key of the on chain program
-						1.1.1.3.1.2. `data` : `String | undefined` - base58 encoded calldata for instruction
+						1.1.1.3.1.2. `data` : `String` - base58 encoded calldata for instruction
 						1.1.1.3.1.3. `keys` : `Array` - account metadata used to define instructions
 							1.1.1.2.1.3.1. `Object` - key
 								1.1.1.3.1.3.1.1. `isSigner` : `Boolean` - true if an instruction requires a transaction signature matching `pubkey`
 								1.1.1.3.1.3.1.2. `isWritable` : `Boolean` - true if the `pubkey` can be loaded as a read-write account
 								1.1.1.3.1.3.1.3. `pubkey` : `String` - public key of authorized program
 				1.1.1.4. `nonceInfo` : `Object` - (optional) Nonce information. If populated, transaction will use a durable Nonce hash instead of a recentBlockhash.
-					1.1.1.4.1	`nonce` : `String` - The current base58 encoded blockhash stored in the nonce
+					1.1.1.4.1 `nonce` : `String` - The current base58 encoded blockhash stored in the nonce
 					1.1.1.4.2 `nonceInstruction` : `Object` AdvanceNonceAccount Instruction. See `1.1.1.3.1` for object layout
-				1.1.1.5. `signatures` : `Array`, - (optional) previous signatures for this instruction set
+				1.1.1.5. `signatures` : `Array`, - previous signatures for this instruction set
 					1.1.1.5.1. `Object` - signature
 						1.1.1.5.1.2. `pubkey` : `String` - pubkey of the signer
 						1.1.1.5.1.1. `signature` : `String` - signature matching `pubkey`
@@ -203,7 +204,7 @@ This method returns a an array of transactions with added signatures by the targ
 				1.1.1.3. `instructions` : `Array` - instructions to be atomically executed:
 					1.1.1.3.1. `Object` - instruction
 						1.1.1.3.1.1. `programId` : `String` - public key of the on chain program
-						1.1.1.3.1.2. `data` : `String | undefined` - base58 encoded calldata for instruction
+						1.1.1.3.1.2. `data` : `String` - base58 encoded calldata for instruction
 						1.1.1.3.1.3. `keys` : `Array` - account metadata used to define instructions
 							1.1.1.3.1.3.1. `Object` - key
 								1.1.1.3.1.3.1.1. `isSigner` : `Boolean` - true if an instruction requires a transaction signature matching `pubkey`
@@ -212,7 +213,7 @@ This method returns a an array of transactions with added signatures by the targ
 				1.1.1.4. `nonceInfo` : `Object` - (optional) Nonce information. If populated, transaction will use a durable Nonce hash instead of a recentBlockhash.
 					1.1.1.4.1 `nonce` : `String` - The current base58 encoded blockhash stored in the nonce
 					1.1.1.4.2 `nonceInstruction` : `Object` AdvanceNonceAccount Instruction. See `1.1.1.3.1` for object layout
-				1.1.1.5. `signatures` : `Array`, - (optional) previous signatures for this instruction set
+				1.1.1.5. `signatures` : `Array`, - previous signatures for this instruction set
 					1.1.1.5.1. `Object` - signature
 						1.1.1.5.1.2. `pubkey` : `String` - pubkey of the signer
 						1.1.1.5.1.1. `signature` : `String` - signature matching `pubkey`
@@ -237,7 +238,8 @@ This method returns a an array of transactions with added signatures by the targ
 					"isWritable": true,
 					"pubkey": "AqP3MyNwDP4L1GJKYhzmaAUdrjzpqJUZjahM7kHpgavm"
 				}]
-			}]
+			}],
+			"signatures": []
 		}]
 	}
 }


### PR DESCRIPTION
This is in an effort to make walletconnect behave more like Solana wallet adapters

This is related to #173 

Todo: Update public implementations
- [x] [Docs](docs/json-rpc/solana.md)
- [x] [Wallet adapter](https://github.com/solana-labs/wallet-adapter/blob/master/packages/wallets/walletconnect/src/adapter.ts) - [Fork](https://github.com/FEDSimp/wallet-adapter)
- [x] [React dApp & Wallet v2 Demo](https://github.com/WalletConnect/web-examples/) - [Fork](https://github.com/FEDSimp/web-examples/)
- [x] [solana-wallet](https://github.com/WalletConnect/solana-wallet) - [PR](https://github.com/WalletConnect/solana-wallet/pull/1)

I'm still seeking comments on this and happy to get it done.

============

**Is your feature request related to a problem? Please describe.**
The current solana RPC implementation is insufficient for Solana wallet adapters. Wallets have no way to modify the transaction if they wish. It also doesn't support offline nonce'd transactions 

**Describe the solution you'd like**
- Respond to solana_signTransaction with the entire transaction with signature added. This is in line with the walled adapter interface
  - Currently only the signature is sent back
  - The signature will also be returned while teams upgrade
- Signature response gets deprecated (Not sure about this one but if teams use it it defeats the purpose of the above)
  - Implementations can rely on signature response if the transaction response isn't present. They assume the transaction has not changed

**Describe alternatives you've considered**
An alternative is solana_sendTransaction which doesn't have this problem. However wallet adapters don't send transactions and are assumed to return a fully signed transaction for the frontend to send

If all other options are exhausted I may create a nonstandard wallet adapter that doesn't follow the RPC spec

**Additional context**
Wallet adapters are the main way solana dApps sign transactions so it makes sense to make RPC suitable for them. Eth doesn't have this issue because it returns the signed transaction