### PR TITLE
Remove bridge server info

### DIFF
--- a/versioned_docs/version-1.0/bridge-server.md
+++ b/versioned_docs/version-1.0/bridge-server.md
@@ -11,22 +11,6 @@
   Body: Hello World, this is WalletConnect v1.0
 ```
 
-## Get Bridge Server Info
-
-```bash
-  GET https://bridge.walletconnect.org/info
-
-  Response:
-  Status: 200
-  Content-Type: application/json; charset=utf-8
-  Body:
-  {
-    "name": "WalletConnect Bridge Server",
-    "repository": "walletconnect-bridge",
-    "version": "1.0"
-  }
-```
-
 ## Subscribe Push Notification Webhook
 
 ```bash


### PR DESCRIPTION
The bridge server info described in the docs is no longer valid.

Removing for clarity.