### PR TITLE
add plausible

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -16,6 +16,7 @@ const config = {
   favicon: "img/favicon.ico",
   organizationName: "walletconnect",
   projectName: "walletconnect-docs",
+  scripts: [{src: 'https://plausible.io/js/plausible.js', defer: true, 'data-domain': 'docs.walletconnect.com'}],
 
   presets: [
     [


### PR DESCRIPTION
Adds simple privacy focused stats to docs.

The goal of Plausible is to understand overall trends in this websites traffic in a privacy-preserving manner, and is not to track individual visitors. Plausbile does not use cookies, does not generate any persistent identifiers and does not collect or store any personal or identifiable data. All of the data is aggregated data only and it has no personal information. All the site measurement is carried out absolutely anonymously. Read more about about [Plausible's data policy](https://plausible.io/data-policy).

Followed the [Plausible guide instructions](https://plausible.io/docs/docusaurus-integration) for Docusaurus.