### PR TITLE
Add iOS App Link Constraints section to Mobile Linking docs

### DIFF
--- a/versioned_docs/version-1.0/mobile-linking.md
+++ b/versioned_docs/version-1.0/mobile-linking.md
@@ -87,3 +87,48 @@ npm install --save @walletconnect/qrcode-modal
 ```
 
 If you would like to build your own UI for mobile linking, you can use our registry API to get app entries and logos however we highly recommend that you use our provided qrcode-modal package to maintain a consistent UX across WalletConnect integrations however we modularized our packages to give the option on the ethos of decentralization.
+
+## iOS App Link Constraints
+
+When using WalletConnect on iOS and triggering a wallet interaction (e.g. when sending a transaction or signing a message), you may experience issues where the native app is not opened as expected and a browser navigation occurs instead. For some wallets (e.g. [Rainbow](https://rainbow.me)) this will present a fallback website, while other wallets (e.g. [MetaMask](https://metamask.io)) will redirect to the App Store.
+
+This issue occurs because app links on iOS will only open the native app when the following rules are followed:
+
+- **The wallet interaction must be triggered by a user-initiated event,** e.g. in a click handler rather than on page load or in an asynchronous callback.
+- **The wallet interaction must be triggered as soon as possible within the event handler.** Any preceding asynchronous work (e.g. estimating gas, resolving an ENS name, fetching a nonce) should have already completed before the event handler fires. This may require you to design the user experience around this constraint, preventing users from initiating a wallet interaction until it's ready rather than doing the work lazily.
+
+**Note that even if your own code follows these rules, libraries you depend on may be running their own asynchronous logic before triggering a wallet interaction.** For example, [Ethers asynchronously populates transactions before sending them.](https://docs.ethers.io/v5/api/signer/#Signer-sendTransaction) Known workarounds are documented below, but if you're still experiencing these issues, you should raise them with the relevant library maintainers.
+
+### For Ethers v5
+
+These are the known workarounds for avoiding app linking issues on iOS when using [Ethers v5](https://docs.ethers.io/v5).
+
+#### When sending a transaction
+
+- **[`signer.sendTransaction`](https://docs.ethers.io/v5/api/signer/#Signer-sendTransaction) should be avoided in favor of [`signer.sendUncheckedTransaction`](https://docs.ethers.io/v5/api/providers/jsonrpc-provider/#JsonRpcSigner-sendUncheckedTransaction).**
+
+  This avoids an asynchronous call to retrieve the internal block number which Ethers uses to resolve a complete [`TransactionResponse`](https://docs.ethers.io/v5/api/providers/types/#providers-TransactionResponse) object.
+
+  Note that as a result of this optimization, `sendUncheckedTransaction` returns a mock transaction response that only contains the `hash` property and a `wait` method. All other properties are `null`.
+
+- **The transaction's `to` property should be a plain address rather than an ENS name.**
+
+  This avoids an asynchronous call to automatically resolve ENS names during the send process.
+
+  If you still want to support ENS name resolution, you should manually run [`provider.resolveName`](https://docs.ethers.io/v5/api/providers/provider/#Provider-ResolveName) ahead of time, storing the result before the user attempts to send a transaction. Do not resolve ENS names in the event handler.
+
+- **The transaction's `gasLimit` property should be set.**
+
+  This avoids the asynchronous work performed in `sendTransaction` which automatically estimates the gas limit if it's missing.
+
+  If you still want to use the same gas limit estimation logic from `sendTransaction`, you should manually run [`provider.estimateGas`](https://docs.ethers.io/v5/api/providers/provider/#Provider-estimateGas) ahead of time, storing the result before the user attempts to send the transaction. Do not estimate gas in the event handler.
+
+#### When calling a write method on a contract
+
+- **[`contract.METHOD_NAME`](https://docs.ethers.io/v5/api/contract/contract/#contract-functionsSend) should be avoided if favor of calling [`contract.populateTransaction.METHOD_NAME`](https://docs.ethers.io/v5/api/contract/contract/#contract-populateTransaction) ahead of time, then sending the populated transaction with [`signer.sendUncheckedTransaction`](https://docs.ethers.io/v5/api/providers/jsonrpc-provider/#JsonRpcSigner-sendUncheckedTransaction).**
+
+- When sending the populated transaction, you should [follow the same guidelines as regular transactions](#when-sending-a-transaction) to avoid any asynchronous logic breaking the app link navigation. Do not populate the contract transaction in the event handler.
+
+#### When signing a message
+
+- If the message depends on the result of an asynchronous call (e.g. retrieving a nonce when implementing [Sign-In With Ethereum](https://login.xyz)), you should do this work ahead of time, storing the result before the user attempts to sign the message. Do not perform this asynchronous work in the event handler.


### PR DESCRIPTION
I've been investigating app link issues with WalletConnect on iOS and found that the corresponding native app isn't opened as expected in certain common scenarios, especially (but not exclusively) when using Ethers. Unfortunately there's no quick fix for it which means that developers will need some guidance on what the issue is and how to avoid it.

I should note that this documentation obviously isn't the ideal end state. @jxom is actively working on [better abstractions in wagmi](https://github.com/tmm/wagmi/pull/658) to deal with this problem and [I've been in contact with Ethers](https://github.com/ethers-io/ethers.js/discussions/3151) about this too to see whether we can get better access to its internals, but in the meantime it would be great for the WalletConnect docs to provide some guidance on this problem since it seems to be quite pervasive.