### PR TITLE
update v2 version to rc

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -38,7 +38,7 @@ const config = {
             },
             current: {
               badge: false,
-              label: "v2.0 beta",
+              label: "v2.0-rc",
               path: "2.0",
             },
           },


### PR DESCRIPTION
Update latest version to "release candidate" instead of beta.  

<img width="396" alt="Screen Shot 2022-07-15 at 12 15 47 PM" src="https://user-images.githubusercontent.com/116099/179204029-8592c959-ddd9-4f52-b535-c324ef53a9b3.png">

