### PR TITLE
docs(auth): integrate findings from dogfooding JS auth docs

### DIFF
--- a/docs/introduction/auth.md
+++ b/docs/introduction/auth.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-WalletConnect Auth is an authentication protocol that can be used to login blockchain wallets into dapps. The Auth API provides a simple and lean interface to enable dapps to authenticate users using a signing message. Using the Auth API, dapps can setup a decentralized on-boarding flow for their users without passwords.
+WalletConnect Auth is an authentication protocol that can be used to login blockchain wallets into dapps. The Auth API provides a simple and lean interface to enable dapps to authenticate users using a signed message. Using the Auth API, dapps can setup a decentralized on-boarding flow for their users without passwords.
 
 ## Getting Started
 
@@ -11,4 +11,3 @@ There are getting started guides for the following clients platforms:
 - [Web - Javascript](../javascript/auth/installation.md)
 - [iOS - Swift](../swift/auth/installation.md)
 - [Android - Kotlin](../kotlin/auth/installation.md)
-

--- a/docs/javascript/auth/dapp-usage.md
+++ b/docs/javascript/auth/dapp-usage.md
@@ -5,31 +5,25 @@ description: Quick Start For Dapps using Auth Client
 # Dapp Usage
 
 :::caution
-**The WalletConnect Auth SDK is currently in early Alpha and is not production-ready**.
+**The WalletConnect Auth SDK is currently in Alpha and is not production-ready**.
 
 Its public API and associated documentation may still see significant and breaking changes.
 :::
 
-This library is compatible with NodeJS, browsers and React-Native applications \(NodeJS modules require polyfills for React-Native\).
-
-## Installation
-
-```bash npm2yarn
-npm install --save @walletconnect/auth-client
-npm install --save-dev @walletconnect/types@rc
-```
-
 ## Request Authentication
 
-**1. Initiate your WalletConnect AuthClient with the relay server, using [your Project ID](../../introduction/cloud.md#project-id).**
+**1. Initialize your WalletConnect AuthClient, using [your Project ID](../../introduction/cloud.md#project-id).**
 
 ```javascript
 import AuthClient from "@walletconnect/auth-client";
 
 const authClient = await AuthClient.init({
   projectId: "<YOUR_PROJECT_ID>",
-  storageOptions: {
-    database: ":memory:",
+  metadata: {
+    name: "my-auth-dapp",
+    description: "A dapp using WalletConnect AuthClient",
+    url: "my-auth-dapp.com",
+    icons: ["https://my-auth-dapp.com/icons/logo.png"],
   },
 });
 ```
@@ -54,7 +48,7 @@ const { uri } = await authClient.request({
 });
 ```
 
-**4. The URI generated can be generated into a QRCode and scanned**
+**4. The provided URI can be generated into a QRCode and scanned**
 
 ```javascript
 import QRCodeModal from "@walletconnect/qrcode-modal";

--- a/docs/javascript/auth/dapp-usage.md
+++ b/docs/javascript/auth/dapp-usage.md
@@ -10,8 +10,6 @@ description: Quick Start For Dapps using Auth Client
 Its public API and associated documentation may still see significant and breaking changes.
 :::
 
-## Request Authentication
-
 **1. Initialize your WalletConnect AuthClient, using [your Project ID](../../introduction/cloud.md#project-id).**
 
 ```javascript

--- a/docs/javascript/auth/dapp-usage.md
+++ b/docs/javascript/auth/dapp-usage.md
@@ -31,9 +31,13 @@ const authClient = await AuthClient.init({
 **2. Add listeners for the `auth_response` event**
 
 ```javascript
-authClient.once("auth_response", ({ params }) => {
-  isSuccessfulResponse = Boolean(params.result?.signature);
-  // Handle successful/unsuccessful response
+authClient.on("auth_response", ({ params }) => {
+  if (Boolean(params.result?.s)) {
+    // Response contained a valid signature -> user is authenticated.
+  } else {
+    // Handle error or invalid signature case
+    console.error(params.message);
+  }
 });
 ```
 

--- a/docs/javascript/auth/installation.md
+++ b/docs/javascript/auth/installation.md
@@ -1,7 +1,7 @@
 # Installation
 
 :::caution
-**The WalletConnect Auth SDK is currently in early Alpha and is not production-ready**.
+**The WalletConnect Auth SDK is currently in Alpha and is not production-ready**.
 
 Its public API and associated documentation may still see significant and breaking changes.
 :::
@@ -16,8 +16,6 @@ Install the WalletConnect client package.
 
 :::info
 For additional type packages refer to our [TypeScript Guide](../guides/typescript).
-
-For platform-specific instructions, refer to our [React Native](../guides/react-native) and [Node.js](../guides/nodejs.md) guides.
 :::
 
 ```bash npm2yarn

--- a/docs/javascript/auth/installation.md
+++ b/docs/javascript/auth/installation.md
@@ -19,17 +19,6 @@ For additional type packages refer to our [TypeScript Guide](../guides/typescrip
 :::
 
 ```bash npm2yarn
-npm install --save @walletconnect/auth-client
-```
-
-## 3. Initialize Client
-
-Initialize client by passing `projectId` we created before.
-
-```javascript
-import AuthClient from "@walletconnect/auth-client";
-
-const authClient = await AuthClient.init({
-  projectId: "<YOUR_PROJECT_ID>",
-});
+npm i @walletconnect/auth-client
+npm i better-sqlite3 # required for @walletconnect/core in Node envs
 ```

--- a/docs/javascript/auth/wallet-usage.md
+++ b/docs/javascript/auth/wallet-usage.md
@@ -1,35 +1,29 @@
 # Wallet Usage
 
 :::caution
-**The WalletConnect Auth SDK is currently in early Alpha and is not production-ready**.
+**The WalletConnect Auth SDK is currently in Alpha and is not production-ready**.
 
 Its public API and associated documentation may still see significant and breaking changes.
 :::
 
-Auth API establishes a session between a wallet and a dapp in order to
-authenticate a user based on their wallet using JSON-RPC.
-
-## Install
-
-```bash npm2yarn
-npm install --save @walletconnect/auth-client
-npm install --save-dev @walletconnect/types@rc
-```
-
-## Initialize the client
+**1. Initialize your WalletConnect AuthClient, using [your Project ID](../../introduction/cloud.md#project-id).**
 
 ```javascript
+import AuthClient from "@walletconnect/auth-client";
+
 const authClient = await AuthClient.init({
   projectId: "<YOUR_PROJECT_ID>",
-  // storageOptions is an optional property, not a must to specify.
-  storageOptions: {
-    database: ":memory:",
-  },
   iss: `did:pkh:eip155:1:<WALLET_ADDRESS>`,
+  metadata: {
+    name: "my-auth-wallet",
+    description: "A wallet using WalletConnect AuthClient",
+    url: "my-auth-wallet.com",
+    icons: ["https://my-auth-wallet.com/icons/logo.png"],
+  },
 });
 ```
 
-## Listen to authentication requests
+**2. Listen to authentication requests**
 
 ```javascript
 authClient.once("auth_request", async (args) => {
@@ -47,7 +41,7 @@ authClient.once("auth_request", async (args) => {
 });
 ```
 
-## Scan QR Code
+**3. Scan QR Code (or paste URI directly)**
 
 Once a QR code is scanned, a pairing must be established using the embedded URI.
 This is what allows the `auth_request` events to be received.

--- a/docs/javascript/auth/wallet-usage.md
+++ b/docs/javascript/auth/wallet-usage.md
@@ -26,13 +26,13 @@ const authClient = await AuthClient.init({
 **2. Listen to authentication requests**
 
 ```javascript
-authClient.once("auth_request", async (args) => {
+authClient.on("auth_request", async ({ id, params }) => {
   // This is a good point to trigger a UI event to provide the user
   // with a button to accept or reject the authentication request,
   // instead of automatically responding.
-  const signature = await wallet.signMessage(args.params.message);
+  const signature = await wallet.signMessage(params.message);
   await authClient.respond({
-    id: args.id,
+    id: id,
     signature: {
       s: signature,
       t: "eip191",


### PR DESCRIPTION
## Description

- Dedupes contradictory and duplicated install steps
- Aligns formatting between dapp and wallet guides
- Tweaks code snippets based on recent spec changes


### TODO

- [ ] Show how to generate nonces with the util once we ship this as part of the `auth-client` pkg
- [ ] Link each usage guide to the respective auth example in the `web-examples` repo