### PR TITLE
Push Server Deprecation Notice

### DIFF
--- a/docs/introduction/push.md
+++ b/docs/introduction/push.md
@@ -1,5 +1,12 @@
 # Push
 
+:::caution
+
+Currently the [v1 Push](/push-server) is in available in v2, over the coming week this is going to be deprecated in favor of the new [Echo Server spec](https://github.com/WalletConnect/echo-server/blob/main/spec/spec.md)
+
+:::
+
+
 ## Introduction
 
 WalletConnect Push is a push notification protocol that enables apps to notify users of both off-chain and on-chain events. The Push API allows wallet users to register subscriptions for different on-chain or off-chain events that are relevant to the user. The notifications are sent to the respective wallets.

--- a/docs/introduction/push.md
+++ b/docs/introduction/push.md
@@ -2,7 +2,7 @@
 
 :::caution
 
-Currently the [v1 Push](/push-server) is in available in v2, over the coming week this is going to be deprecated in favor of the new [Echo Server spec](https://github.com/WalletConnect/echo-server/blob/main/spec/spec.md)
+Currently the [v1 Push](/push-server) is in available in v2, over the coming weeks this is going to be deprecated in favor of the new [Echo Server spec](https://github.com/WalletConnect/echo-server/blob/main/spec/spec.md) and support for the Push Server API will be removed.
 
 :::
 

--- a/docs/introduction/sign.md
+++ b/docs/introduction/sign.md
@@ -1,5 +1,11 @@
 # Sign
 
+:::caution
+
+Currently the [v1 Push](/push-server) is in available in v2, over the coming week this is going to be deprecated in favor of the new [Echo Server spec](https://github.com/WalletConnect/echo-server/blob/main/spec/spec.md)
+
+:::
+
 ## Introduction
 
 WalletConnect Sign is a remote signer protocol to communicate securely between web3 wallets and dapps. The protocol establishes a remote pairing between two apps and/or devices using a Relay server to relay payloads. These payloads are symmetrically encrypted through a shared key between the two peers. The pairing is initiated by one peer displaying a QR Code or deep link with a standard WalletConnect URI and is established when the counter-party approves this pairing request.

--- a/docs/introduction/sign.md
+++ b/docs/introduction/sign.md
@@ -1,11 +1,5 @@
 # Sign
 
-:::caution
-
-Currently the [v1 Push](/push-server) is in available in v2, over the coming week this is going to be deprecated in favor of the new [Echo Server spec](https://github.com/WalletConnect/echo-server/blob/main/spec/spec.md)
-
-:::
-
 ## Introduction
 
 WalletConnect Sign is a remote signer protocol to communicate securely between web3 wallets and dapps. The protocol establishes a remote pairing between two apps and/or devices using a Relay server to relay payloads. These payloads are symmetrically encrypted through a shared key between the two peers. The pairing is initiated by one peer displaying a QR Code or deep link with a standard WalletConnect URI and is established when the counter-party approves this pairing request.

--- a/versioned_docs/version-1.0/push-server.md
+++ b/versioned_docs/version-1.0/push-server.md
@@ -1,5 +1,11 @@
 # Push Server API Reference
 
+:::info
+
+If you are looking at implementing push for v2, please refer to the new [Echo Server spec](https://github.com/WalletConnect/echo-server/blob/main/spec/spec.md) as support for the Push Server API is being removed from v2 in the coming weeks.
+
+:::
+
 ## Register Push Notification Subscription
 
 ```bash
@@ -42,4 +48,3 @@
       "success": true
   }
 ```
-


### PR DESCRIPTION
This PR adds deprecation notices for Push API support in v2 and directs users to the Echo Server spec which will be supported in the coming weeks