### PR TITLE
fix(pair): adds missing RPC methods

### DIFF
--- a/docs/specs/pair/rpc-methods.md
+++ b/docs/specs/pair/rpc-methods.md
@@ -1,0 +1,86 @@
+# RPC Methods
+
+This doc should be used as a _source-of-truth_ and reflect the latest decisions and changes applied to the WalletConnect collection of client-to-client JSON-RPC methods for all platforms SDKs.
+
+## Definitions
+
+- **Nullables:** Fields flagged as `Optional` can be ommited from the payload.
+- Unless explicitly mentioned that a response requires associated data, all methods response's follow a default JSON-RPC pattern for the success and failure cases:
+
+```jsonc
+// Success
+result: true
+
+// Failure
+error: {
+  "code": number,
+  "message": string
+}
+```
+
+## Pairing
+
+### wc_pairingDelete
+
+Used to inform the peer to close and delete a pairing. All associated sessions of the given pairing must also be deleted.
+
+**Request**
+
+```jsonc
+// wc_pairingDelete params
+{
+  "code": Int64,
+  "message": string
+}
+
+| IRN     |          |
+| ------- | -------- |
+| TTL     | 86400    |
+| Prompt  | false    |
+| Tag     | 1000     |
+```
+
+**Response**
+
+```jsonc
+// Success result
+true
+
+| IRN     |          |
+| ------- | -------- |
+| TTL     | 86400    |
+| Prompt  | false    |
+| Tag     | 1001     |
+```
+
+### wc_pairingPing
+
+Used to evaluate if peer is currently online. Timeout at 30 seconds
+
+**Request**
+
+```jsonc
+// wc_pairingPing params
+{
+  // empty
+}
+
+| IRN     |          |
+| ------- | -------- |
+| TTL     | 30       |
+| Prompt  | false    |
+| Tag     | 1002     |
+```
+
+**Response**
+
+```jsonc
+// Success result
+true
+
+| IRN     |          |
+| ------- | -------- |
+| TTL     | 30       |
+| Prompt  | false    |
+| Tag     | 1003     |
+```


### PR DESCRIPTION
- As discussed during SDK sync call on 28.09.2022
- Adds `wc_` RPC methods that were removed from the other SDK specs