### PR TITLE
Make v2 the default docs version

### DIFF
--- a/docs/introduction/push.md
+++ b/docs/introduction/push.md
@@ -2,10 +2,9 @@
 
 :::caution
 
-Currently the [v1 Push](/push-server) is in available in v2, over the coming weeks this is going to be deprecated in favor of the new [Echo Server spec](https://github.com/WalletConnect/echo-server/blob/main/spec/spec.md) and support for the Push Server API will be removed.
+Currently the [v1 Push](/1.0/push-server) is available in v2, over the coming weeks this is going to be deprecated in favor of the new [Echo Server spec](https://github.com/WalletConnect/echo-server/blob/main/spec/spec.md) and support for the Push Server API will be removed.
 
 :::
-
 
 ## Introduction
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -25,7 +25,7 @@ const config = {
       {
         docs: {
           breadcrumbs: false,
-          lastVersion: "1.0",
+          lastVersion: "current",
           routeBasePath: "/",
           sidebarPath: require.resolve("./sidebars.js"),
           showLastUpdateTime: true,
@@ -35,11 +35,11 @@ const config = {
             "1.0": {
               badge: false,
               label: "v1.0",
-              path: "/",
+              path: "1.0",
             },
             current: {
               badge: false,
-              label: "v2.0-rc",
+              label: "v2.0",
               path: "2.0",
             },
           },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -159,14 +159,6 @@ const config = {
         indexName: "walletconnect",
         contextualSearch: true,
       },
-      announcementBar: {
-        id: 'support_us',
-        content:
-          '⚠️ Getting started? For dapps, use <a rel="noopener noreferrer" href="/1.0/">v1</a>.  For wallets, use both <a rel="noopener noreferrer" href="/1.0/">v1</a> and <a rel="noopener noreferrer" href="/2.0/">v2</a> together. <a rel="noopener noreferrer" href="/2.0/advanced/migrating-from-v1.0">Learn more.</a>',
-        backgroundColor: '#3182ce',
-        textColor: '#fff',
-        isCloseable: true,
-      },
     },
 };
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -162,7 +162,7 @@ const config = {
       announcementBar: {
         id: 'support_us',
         content:
-          '⚠️ Getting started? For dapps, use <a rel="noopener noreferrer" href="/1.0/">v1</a>.  For wallets, use both <a rel="noopener noreferrer" href="/">v1</a> and <a rel="noopener noreferrer" href="/2.0/">v2</a> together. <a rel="noopener noreferrer" href="/2.0/advanced/migrating-from-v1.0">Learn more.</a>',
+          '⚠️ Getting started? For dapps, use <a rel="noopener noreferrer" href="/1.0/">v1</a>.  For wallets, use both <a rel="noopener noreferrer" href="/1.0/">v1</a> and <a rel="noopener noreferrer" href="/2.0/">v2</a> together. <a rel="noopener noreferrer" href="/2.0/advanced/migrating-from-v1.0">Learn more.</a>',
         backgroundColor: '#3182ce',
         textColor: '#fff',
         isCloseable: true,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -162,7 +162,7 @@ const config = {
       announcementBar: {
         id: 'support_us',
         content:
-          '⚠️ Getting started? For dapps, use <a rel="noopener noreferrer" href="/">v1</a>.  For wallets, use both <a rel="noopener noreferrer" href="/">v1</a> and <a rel="noopener noreferrer" href="/2.0/">v2</a> together. <a rel="noopener noreferrer" href="/2.0/advanced/migrating-from-v1.0">Learn more.</a>',
+          '⚠️ Getting started? For dapps, use <a rel="noopener noreferrer" href="/1.0/">v1</a>.  For wallets, use both <a rel="noopener noreferrer" href="/">v1</a> and <a rel="noopener noreferrer" href="/2.0/">v2</a> together. <a rel="noopener noreferrer" href="/2.0/advanced/migrating-from-v1.0">Learn more.</a>',
         backgroundColor: '#3182ce',
         textColor: '#fff',
         isCloseable: true,

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import {Redirect} from '@docusaurus/router';
+
+const Home = () => {
+  return <Redirect to="/2.0/" />;
+};
+
+export default Home;

--- a/vercel.json
+++ b/vercel.json
@@ -8,6 +8,66 @@
     {
       "source": "/v/2.0/:path*",
       "destination": "/2.0/:path*"
+    },
+    {
+      "source": "/quick-start/dapps/client",
+      "destination": "/1.0/quick-start/dapps/client"
+    },
+    {
+      "source": "/quick-start/dapps/node",
+      "destination": "/1.0/quick-start/dapps/node"
+    },
+    {
+      "source": "/quick-start/dapps/react-native",
+      "destination": "/1.0/quick-start/dapps/react-native"
+    },
+    {
+      "source": "/quick-start/dapps/web3-provider",
+      "destination": "/1.0/quick-start/dapps/web3-provider"
+    },
+    {
+      "source": "/quick-start/dapps/web3modal",
+      "destination": "/1.0/quick-start/dapps/web3modal"
+    },
+    {
+      "source": "/quick-start/wallets/kotlin",
+      "destination": "/1.0/quick-start/wallets/kotlin"
+    },
+    {
+      "source": "/quick-start/wallets/swift",
+      "destination": "/1.0/quick-start/wallets/swift"
+    },
+    {
+      "source": "/quick-start/wallets/react-native",
+      "destination": "/1.0/quick-start/wallets/react-native"
+    },
+    {
+      "source": "/json-rpc-api-methods/ethereum",
+      "destination": "/1.0/json-rpc-api-methods/ethereum"
+    },
+    {
+      "source": "/smart-wallets",
+      "destination": "/1.0/smart-wallets"
+    },
+    {
+      "source": "/mobile-linking",
+      "destination": "/1.0/mobile-linking"
+    },
+    {
+      "source": "/legacy-clients",
+      "destination": "/1.0/legacy-clients"
+    },
+    {
+      "source": "/client-api",
+      "destination": "/1.0/client-api"
+    },
+    {
+      "source": "/bridge-server",
+      "destination": "/1.0/bridge-server"
+    },
+    {
+      "source": "/push-server",
+      "destination": "/1.0/push-server"
     }
   ]
 }


### PR DESCRIPTION
v2 is final, so this change makes makes v2 the current version!

Paths are now:

v2 - `/2.0/`
v1 - `/1.0/` 

A redirect was added from `/` to make `/2.0` the default start page.

NOTE: This PR breaks the permalinks for v1 docs since previously v1 content was at `/`, but now it is `/1.0`.  Vercel redirects were added to handle this.