### PR TITLE
delete old beta migration links

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -17,7 +17,6 @@ In this repository, we document and discuss features that are currently under de
 - Client API ([doc](sign/client-api.md))
 - Data Structures ([doc](sign/data-structures.md))
 - Error Codes ([doc](sign/error-codes.md))
-- Migration ([doc](sign/migration.md))
 
 ### Chat
 
@@ -60,4 +59,3 @@ In this repository, we document and discuss features that are currently under de
 - Error Codes ([doc](core/pairing/error-codes.md))
 - Data Structures ([doc](core/pairing/data-structures.md))
 - RPC Methods ([doc](core/pairing/rpc-methods.md))
-

--- a/docs/specs/sign/migration.md
+++ b/docs/specs/sign/migration.md
@@ -1,7 +1,0 @@
-# Migration
-
-Here are the links to migration documentation for each platform:
-
-- Swift - https://gist.github.com/llbartekll/2048f1a53799430b12a321d7d149db43
-- Kotlin - https://gist.github.com/jakobuid/d425a77fc2cc88d39c994f44931d925f
-- Javascript - https://gist.github.com/pedrouid/1a36c6a8776e49453838578ec84715e6


### PR DESCRIPTION
Deleting this page, since we no longer have any clients using the beta clients.