### PR TITLE
Docs: Add Sign as dependency to Auth

### DIFF
--- a/docs/javascript/auth/installation.md
+++ b/docs/javascript/auth/installation.md
@@ -6,12 +6,15 @@ Head over to [WalletConnect Cloud](https://cloud.walletconnect.com/) to sign in 
 
 ## 2. Install Packages
 
-Install the WalletConnect client package.
+For Dapps, only install Auth. If you're building a wallet, you will need to install the [Sign](../sign/installation.md) client too.
 
-:::info
-For additional type packages refer to our [TypeScript Guide](../guides/typescript).
-:::
-
+### Dapps
 ```bash npm2yarn
 npm install @walletconnect/auth-client
+```
+
+### Wallets
+```bash npm2yarn
+npm install @walletconnect/auth-client
+npm install @walletconnect/sign-client
 ```

--- a/docs/javascript/auth/installation.md
+++ b/docs/javascript/auth/installation.md
@@ -2,19 +2,16 @@
 
 ## 1. Obtain Project ID
 
-Head over to [WalletConnect Cloud](https://cloud.walletconnect.com/) to sign in or sign up. Create (or use an existing) project and copy its associated Project ID. We will need this in a later step.
+Head over to [WalletConnect Cloud](https://cloud.walletconnect.com/) to sign in or sign up. Create (or use an existing) project and copy its associated Project ID. We will need this in a later step. If you're building a wallet, we highly encourage you to also install [Auth](../auth/installation.md).
 
 ## 2. Install Packages
 
-For Dapps, only install Auth. If you're building a wallet, you will need to install the [Sign](../sign/installation.md) client too.
+Install the WalletConnect client package.
 
-### Dapps
+:::info
+For additional type packages refer to our [TypeScript Guide](../guides/typescript).
+:::
+
 ```bash npm2yarn
 npm install @walletconnect/auth-client
-```
-
-### Wallets
-```bash npm2yarn
-npm install @walletconnect/auth-client
-npm install @walletconnect/sign-client
 ```

--- a/docs/javascript/sign/installation.md
+++ b/docs/javascript/sign/installation.md
@@ -15,5 +15,5 @@ For platform-specific instructions, refer to our [React Native](../guides/react-
 :::
 
 ```bash npm2yarn
-npm install --save @walletconnect/sign-client
+npm install @walletconnect/sign-client
 ```


### PR DESCRIPTION
Update text to let Wallets know they need to integrate Sign when using Auth.