### PR TITLE
Add W3M to JavaScript products

### DIFF
--- a/docs/web3modal/about.md
+++ b/docs/web3modal/about.md
@@ -1,4 +1,4 @@
-# About
+# Web3Modal
 
 Your on-ramp to web3 multichain. Web3Modal is a versatile library that makes it super easy to connect users with your Dapp and start interacting with the blockchain.
 
@@ -22,3 +22,8 @@ You can further customize the modal by specifying it's theme and accent color (s
 ### Preview
 
 ![web3modal customisation](/assets/modal_preview.png)
+
+## Get Started
+
+To get started, click [here](./standalone.md).
+

--- a/docs/web3modal/about.md
+++ b/docs/web3modal/about.md
@@ -25,5 +25,5 @@ You can further customize the modal by specifying it's theme and accent color (s
 
 ## Get Started
 
-To get started, click [here](./standalone.md).
+To get started, click [here](./react/installation.md).
 

--- a/docs/web3modal/about.md
+++ b/docs/web3modal/about.md
@@ -6,6 +6,10 @@ Your on-ramp to web3 multichain. Web3Modal is a versatile library that makes it 
 
 The Web3Modal Github can be found at [https://github.com/WalletConnect/web3modal](https://github.com/WalletConnect/web3modal).
 
+## Get Started
+
+To get started, click [here](./react/installation.md) to learn how to implement Web3Modal to your project.
+
 ## Customization
 
 Web3Modal automatically adapts to display desktop or mobile wallets depending on the user's device. Furthermore, we will only show wallets that support your configured chains.
@@ -22,8 +26,4 @@ You can further customize the modal by specifying it's theme and accent color (s
 ### Preview
 
 ![web3modal customisation](/assets/modal_preview.png)
-
-## Get Started
-
-To get started, click [here](./react/installation.md).
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -158,6 +158,7 @@ module.exports = {
           collapsible: true,
           collapsed: true,
           items: [
+            "web3modal/standalone",
             {
               type: "category",
               label: "React",
@@ -168,7 +169,6 @@ module.exports = {
                 "web3modal/react/hooks",
               ],
             },
-            "web3modal/standalone",
             "web3modal/for-wallets",
           ]
         },

--- a/sidebars.js
+++ b/sidebars.js
@@ -17,27 +17,7 @@ module.exports = {
       collapsible: false,
       className: "menu_outer_list",
       items: [
-        {
-          type: "category",
-          label: "Web3Modal",
-          collapsed: true,
-          collapsible: true,
-          items: [
-            "web3modal/about",
-            {
-              type: "category",
-              label: "React",
-              collapsed: true,
-              collapsible: true,
-              items: [
-                "web3modal/react/installation",
-                "web3modal/react/hooks",
-              ],
-            },
-            "web3modal/standalone",
-            "web3modal/for-wallets",
-          ],
-        },
+        "web3modal/about",
         {
           type: "category",
           label: "APIs",
@@ -172,6 +152,26 @@ module.exports = {
       className: "menu_outer_list",
       collapsible: false,
       items: [
+        {
+          type: "category",
+          label: "Web3Modal",
+          collapsible: true,
+          collapsed: true,
+          items: [
+            {
+              type: "category",
+              label: "React",
+              collapsed: true,
+              collapsible: true,
+              items: [
+                "web3modal/react/installation",
+                "web3modal/react/hooks",
+              ],
+            },
+            "web3modal/standalone",
+            "web3modal/for-wallets",
+          ]
+        },
         {
           type: "category",
           label: "Sign",

--- a/sidebars.js
+++ b/sidebars.js
@@ -158,7 +158,6 @@ module.exports = {
           collapsible: true,
           collapsed: true,
           items: [
-            "web3modal/standalone",
             {
               type: "category",
               label: "React",
@@ -169,6 +168,7 @@ module.exports = {
                 "web3modal/react/hooks",
               ],
             },
+            "web3modal/standalone",
             "web3modal/for-wallets",
           ]
         },


### PR DESCRIPTION
Chad noticed Web3Modal isn't mentioned in JavaScript products, so I added all but the `About` page to JavaScript products.

Slack Conversation: https://walletconnect.slack.com/archives/C03US3FRU9L/p1668499446473969

