### PR TITLE
[Relay] Timestamp for Subscription Params

### DIFF
--- a/docs/specs/core/relay/relay-server.md
+++ b/docs/specs/core/relay/relay-server.md
@@ -78,7 +78,8 @@ Used when a server sends a subscription message to a client.
     "id" : string,
     "data" : {
       "topic" : string,
-      "message": string
+      "message": string,
+      "timestamp": number,
     }
   }
 }


### PR DESCRIPTION
## Problem
Current Chat API implementation assumes that the sender sends a timestamp in an encrypted payload. This is not entirely reliable information, since the device from which the message is sent can be disconnected from the network, and the message will be sent, for example, in a day.

## Proposal 
Add the timestamp when relay received the message. Also we can stop passing timestamp value in RPCID and use only timestamp from subscription params. 
