### PR TITLE
[Spec] Auth Multi Account

### DIFF
--- a/docs/specs/clients/auth/client-api.md
+++ b/docs/specs/clients/auth/client-api.md
@@ -8,13 +8,16 @@ abstract class Client {
   public abstract init(): Promise<void>;
 
   // request wallet authentication
-  public abstract request(params: RequestParams, topic: string ): Promise<{ uri, id }>;
+  public abstract request(params: RequestParams, topic: string): Promise<{ uri, id }>;
 
   // respond wallet authentication
-  public abstract respond(params: RespondParams, account: Account): Promise<boolean>;
+  public abstract respond(params: RespondParams, iss: string): Promise<boolean>;
 
   // query all pending requests
   public abstract getPendingRequests(): Promise<Record<number, PendingRequest>>;
+
+  // format payload to SIWE message string 
+  public abstract formatMessage(payload: PayloadParams, iss: string): Promise<string>;
 
   // ---------- Events ----------------------------------------------- //
 

--- a/docs/specs/clients/auth/client-api.md
+++ b/docs/specs/clients/auth/client-api.md
@@ -22,6 +22,6 @@ abstract class Client {
   public abstract on("auth_response", (id: number, response: Response) => {}): void;
 
   // for wallet to listen on auth request
-  public abstract on("auth_request", (id: number, message: string) => {}): void;
+  public abstract on("auth_request", (id: number, payload: PayloadParams) => {}): void;
 }
 ```

--- a/docs/specs/clients/auth/client-api.md
+++ b/docs/specs/clients/auth/client-api.md
@@ -5,13 +5,13 @@ abstract class Client {
   // ---------- Methods ----------------------------------------------- //
 
   // initializes the client with persisted storage and a network connection
-  public abstract init(params: { iss?: string }): Promise<void>;
+  public abstract init(): Promise<void>;
 
   // request wallet authentication
   public abstract request(params: RequestParams, topic: string ): Promise<{ uri, id }>;
 
   // respond wallet authentication
-  public abstract respond(params: RespondParams): Promise<boolean>;
+  public abstract respond(params: RespondParams, account: Account): Promise<boolean>;
 
   // query all pending requests
   public abstract getPendingRequests(): Promise<Record<number, PendingRequest>>;

--- a/docs/specs/clients/auth/data-structures.md
+++ b/docs/specs/clients/auth/data-structures.md
@@ -56,7 +56,6 @@ type Response = Cacao | ErrorResponse;
 interface PendingRequest {
   id: number;
   payloadParams: PayloadParams;
-  message: string;
 }
 ```
 


### PR DESCRIPTION
## Description

To support multi-account feature SDK should not store Account object. Account will be passed with `respond` method. 

This makes problematic to generate finalised SIWE message for clients. I suggest to open SIWEMessageFormatter interface to allow this: 

```swift
protocol SIWEMessageFormatting {
    func formatMessage(from payload: PayloadParams, address: String) -> String?
}
```