### PR TITLE
chore: update example

### DIFF
--- a/docs/advanced/rpc-reference/ethereum-rpc.md
+++ b/docs/advanced/rpc-reference/ethereum-rpc.md
@@ -215,13 +215,11 @@ Creates new message call transaction or a contract creation, if the data field c
 [
   {
     from: "0xb60e8dd61c5d32be8058bb8eb970870f07233155",
-    to: "0xd46e8dd67c5d32be8058bb8eb970870f07244567",
-    data:
-      "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675",
-    gas: "0x76c0", // 30400
-    gasPrice: "0x9184e72a000", // 10000000000000
-    value: "0x9184e72a", // 2441406250
-    nonce: "0x117", // 279
+    to: "0xBDE1EAE59cE082505bB73fedBa56252b1b9C60Ce",
+    data: "0x",
+    gasPrice: "0x029104e28c",
+    gasLimit: "0x5208",
+    value: "0x00",
   },
 ];
 ```
@@ -273,8 +271,7 @@ Signs a transaction that can be submitted to the network at a later time using w
   {
     from: "0xb60e8dd61c5d32be8058bb8eb970870f07233155",
     to: "0xd46e8dd67c5d32be8058bb8eb970870f07244567",
-    data:
-      "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675",
+    data: "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675",
     gas: "0x76c0", // 30400
     gasPrice: "0x9184e72a000", // 10000000000000
     value: "0x9184e72a", // 2441406250


### PR DESCRIPTION
When testing the example parameter for this method, it fails. I am updating them to a working example. 

* Note, the `from` address needs to be an account with funds. 