### PR TITLE
Add missing word in Auth API docs

### DIFF
--- a/docs/specs/clients/auth/README.md
+++ b/docs/specs/clients/auth/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Auth API provides a simple and lean interface to enable applications to authenticate wallet users to login/signin into applications with their wallets by automatically an authentication message.
+Auth API provides a simple and lean interface to enable applications to authenticate wallet users to login/signin into applications with their wallets by automatically signing an authentication message.
 
 ## Context
 


### PR DESCRIPTION
missing word "signing"