### PR TITLE
add optional params to dapp example

### DIFF
--- a/docs/javascript/sign/dapp-usage.md
+++ b/docs/javascript/sign/dapp-usage.md
@@ -37,6 +37,8 @@ import SignClient from "@walletconnect/sign-client";
 
 const signClient = await SignClient.init({
   projectId: "<YOUR_PROJECT_ID>",
+  // optional parameters
+  relayUrl: "<YOUR RELAY URL>",
   metadata: {
     name: "Example Dapp",
     description: "Example Dapp",


### PR DESCRIPTION
- Add `relayUrl` as optional parameters to the dapp usage docs