### PR TITLE
New session doc

### DIFF
--- a/docs/specs/clients/auth/session-events.md
+++ b/docs/specs/clients/auth/session-events.md
@@ -1,0 +1,179 @@
+import Table from '../../../components/Table';
+
+# Session Events
+
+## Events
+
+<Table 
+headers={[ "Events", "Description" ]}
+data={[
+{
+event: "auth_request",
+description: "Sent by the WalletConnect client when requesting authentication from your wallet.",
+},
+{
+event: "auth_response",
+description: "Sent by the WalletConnect server when it acceps or rejects an authorization request."
+},
+]}
+/>
+
+## Methods
+
+<Table 
+headers={[ "Sign v2", "Web3Wallet", "Auth", "Description", "Event On", "Event Triggered" ]}
+data={[
+{
+methodSign: "connect",
+methodWallet: "?",
+methodAuth: "?",
+description: "Establishes a connection with a WalletConnect server",
+eventOn: "N/A",
+eventTriggered: "session_connect"
+},
+{
+methodSign: "connect",
+methodWallet: "?",
+methodAuth: "?",
+description: "Establishes a connection with a WalletConnect server",
+eventOn: "N/A",
+eventTriggered: "session_connect"
+},
+{
+methodSign: "pair",
+methodWallet: "?",
+methodAuth: "jshadvas",
+description: "Pair with a WalletConnect server using a pairing topic and URI",
+eventOn: "N/A",
+eventTriggered: "session_connect"
+},
+{
+methodSign: "approve",
+methodWallet: "approveSession",
+methodAuth: "jshadvas",
+description: "Establishes a connection with a WalletConnect server",
+eventOn: "N/A",
+eventTriggered: "session_connect"
+},
+{
+methodSign: "reject",
+methodWallet: "rejectSession",
+methodAuth: "jshadvas",
+description: "Establishes a connection with a WalletConnect server",
+eventOn: "N/A",
+eventTriggered: "session_connect"
+},
+{
+methodSign: "update",
+methodWallet: "updateSession",
+methodAuth: "jshadvas",
+description: "Establishes a connection with a WalletConnect server",
+eventOn: "N/A",
+eventTriggered: "session_connect"
+},
+{
+methodSign: "extend",
+methodWallet: "extendSession",
+methodAuth: "jshadvas",
+description: "Establishes a connection with a WalletConnect server",
+eventOn: "N/A",
+eventTriggered: "session_connect"
+},
+{
+methodSign: "request",
+methodWallet: "X",
+methodAuth: "request",
+description: "Send a method call request to a WalletConnect server",
+eventOn: "N/A",
+eventTriggered: "session_connect"
+},
+{
+methodSign: "respond",
+methodWallet: "respondSessionRequest",
+methodAuth: "X",
+description: "Responds to a session request",
+eventOn: "client.on('session_request')",
+eventTriggered: "session_respond"
+},
+{
+methodSign: "ping",
+methodWallet: "jshadvas",
+methodAuth: "jshadvas",
+description: "Establishes a connection with a WalletConnect server",
+eventOn: "N/A",
+eventTriggered: "session_connect"
+},
+{
+methodSign: "emit",
+methodWallet: "emitSessionEvent",
+methodAuth: "jshadvas",
+description: "Emits an event to an active session",
+eventOn: "N/A",
+eventTriggered: "session_event"
+},
+{
+methodSign: "disconnect",
+methodWallet: "disconnectSession",
+methodAuth: "jshadvas",
+description: "Disconnects ",
+eventOn: "N/A",
+eventTriggered: "session_connect"
+},
+{
+methodSign: "find",
+methodWallet: "jshadvas",
+methodAuth: "jshadvas",
+description: "Establishes a connection with a WalletConnect server",
+eventOn: "N/A",
+eventTriggered: "session_connect"
+},
+{
+methodSign: "getPendingSessionRequests",
+methodWallet: "jshadvas",
+methodAuth: "jshadvas",
+description: "Establishes a connection with a WalletConnect server",
+eventOn: "N/A",
+eventTriggered: "session_connect"
+},
+{
+methodSign: "getAll",
+methodWallet: "jshadvas",
+methodAuth: "jshadvas",
+description: "Establishes a connection with a WalletConnect server",
+eventOn: "N/A",
+eventTriggered: "session_connect"
+},
+{
+methodSign: "proposal.getAll",
+methodWallet: "getPendingSessionProposals",
+methodAuth: "jshadvas",
+description: "Establishes a connection with a WalletConnect server",
+eventOn: "N/A",
+eventTriggered: "session_connect"
+},
+{
+methodSign: "x",
+methodWallet: "respondAuthRequest",
+methodAuth: "respond",
+description: "Establishes a connection with a WalletConnect server",
+eventOn: "N/A",
+eventTriggered: "session_connect"
+},
+{
+methodSign: "x",
+methodWallet: "getPendingAuthRequests",
+methodAuth: "getPendingRequests",
+description: "Establishes a connection with a WalletConnect server",
+eventOn: "N/A",
+eventTriggered: "session_connect"
+},
+{
+methodSign: "x",
+methodWallet: "formatMessage",
+methodAuth: "formatMessage",
+description: "Establishes a connection with a WalletConnect server",
+eventOn: "N/A",
+eventTriggered: "session_connect"
+},
+]}
+/>

--- a/docs/specs/clients/auth/session-events.md
+++ b/docs/specs/clients/auth/session-events.md
@@ -1,8 +1,9 @@
 import Table from '../../../components/Table';
 
 # Session Events
-
 ## Events
+
+You can set up event listeners to perform an action if these events are emitted.
 
 <Table 
 headers={[ "Events", "Description" ]}
@@ -18,162 +19,36 @@ description: "Sent by the WalletConnect server when it acceps or rejects an auth
 ]}
 />
 
-## Methods
+## Triggering Events
+
+To trigger one of the events from above, you generally need to call an action. Below are a list of methods and their associated events. This is not a full list of the function available, just the ones that emit an event.
 
 <Table 
-headers={[ "Sign v2", "Web3Wallet", "Auth", "Description", "Event On", "Event Triggered" ]}
+headers={[ "Method", "Description", "Event On", "Event Triggered" ]}
 data={[
 {
-methodSign: "connect",
-methodWallet: "?",
-methodAuth: "?",
-description: "Establishes a connection with a WalletConnect server",
-eventOn: "N/A",
-eventTriggered: "session_connect"
-},
-{
-methodSign: "connect",
-methodWallet: "?",
-methodAuth: "?",
-description: "Establishes a connection with a WalletConnect server",
-eventOn: "N/A",
-eventTriggered: "session_connect"
-},
-{
-methodSign: "pair",
-methodWallet: "?",
-methodAuth: "jshadvas",
-description: "Pair with a WalletConnect server using a pairing topic and URI",
-eventOn: "N/A",
-eventTriggered: "session_connect"
-},
-{
-methodSign: "approve",
-methodWallet: "approveSession",
-methodAuth: "jshadvas",
-description: "Establishes a connection with a WalletConnect server",
-eventOn: "N/A",
-eventTriggered: "session_connect"
-},
-{
-methodSign: "reject",
-methodWallet: "rejectSession",
-methodAuth: "jshadvas",
-description: "Establishes a connection with a WalletConnect server",
-eventOn: "N/A",
-eventTriggered: "session_connect"
-},
-{
-methodSign: "update",
-methodWallet: "updateSession",
-methodAuth: "jshadvas",
-description: "Establishes a connection with a WalletConnect server",
-eventOn: "N/A",
-eventTriggered: "session_connect"
-},
-{
-methodSign: "extend",
-methodWallet: "extendSession",
-methodAuth: "jshadvas",
-description: "Establishes a connection with a WalletConnect server",
-eventOn: "N/A",
-eventTriggered: "session_connect"
-},
-{
-methodSign: "request",
-methodWallet: "X",
 methodAuth: "request",
 description: "Send a method call request to a WalletConnect server",
-eventOn: "N/A",
-eventTriggered: "session_connect"
+eventOn: "none",
+eventTriggered: "auth_request"
 },
 {
-methodSign: "respond",
-methodWallet: "respondSessionRequest",
-methodAuth: "X",
-description: "Responds to a session request",
-eventOn: "client.on('session_request')",
-eventTriggered: "session_respond"
-},
-{
-methodSign: "ping",
-methodWallet: "jshadvas",
-methodAuth: "jshadvas",
-description: "Establishes a connection with a WalletConnect server",
-eventOn: "N/A",
-eventTriggered: "session_connect"
-},
-{
-methodSign: "emit",
-methodWallet: "emitSessionEvent",
-methodAuth: "jshadvas",
-description: "Emits an event to an active session",
-eventOn: "N/A",
-eventTriggered: "session_event"
-},
-{
-methodSign: "disconnect",
-methodWallet: "disconnectSession",
-methodAuth: "jshadvas",
-description: "Disconnects ",
-eventOn: "N/A",
-eventTriggered: "session_connect"
-},
-{
-methodSign: "find",
-methodWallet: "jshadvas",
-methodAuth: "jshadvas",
-description: "Establishes a connection with a WalletConnect server",
-eventOn: "N/A",
-eventTriggered: "session_connect"
-},
-{
-methodSign: "getPendingSessionRequests",
-methodWallet: "jshadvas",
-methodAuth: "jshadvas",
-description: "Establishes a connection with a WalletConnect server",
-eventOn: "N/A",
-eventTriggered: "session_connect"
-},
-{
-methodSign: "getAll",
-methodWallet: "jshadvas",
-methodAuth: "jshadvas",
-description: "Establishes a connection with a WalletConnect server",
-eventOn: "N/A",
-eventTriggered: "session_connect"
-},
-{
-methodSign: "proposal.getAll",
-methodWallet: "getPendingSessionProposals",
-methodAuth: "jshadvas",
-description: "Establishes a connection with a WalletConnect server",
-eventOn: "N/A",
-eventTriggered: "session_connect"
-},
-{
-methodSign: "x",
-methodWallet: "respondAuthRequest",
 methodAuth: "respond",
-description: "Establishes a connection with a WalletConnect server",
-eventOn: "N/A",
-eventTriggered: "session_connect"
+description: "Responds to an authoirzation request",
+eventOn: "client.on('auth_request')",
+eventTriggered: "auth_response"
 },
 {
-methodSign: "x",
-methodWallet: "getPendingAuthRequests",
 methodAuth: "getPendingRequests",
 description: "Establishes a connection with a WalletConnect server",
-eventOn: "N/A",
-eventTriggered: "session_connect"
+eventOn: "none",
+eventTriggered: "none"
 },
 {
-methodSign: "x",
-methodWallet: "formatMessage",
 methodAuth: "formatMessage",
 description: "Establishes a connection with a WalletConnect server",
-eventOn: "N/A",
-eventTriggered: "session_connect"
+eventOn: "none",
+eventTriggered: "none"
 },
 ]}
 />

--- a/docs/specs/clients/sign/session-events.md
+++ b/docs/specs/clients/sign/session-events.md
@@ -1,0 +1,133 @@
+import Table from '../../../components/Table';
+
+# Session Events
+
+## Events
+
+You can set up event listeners to perform an action if these events are emitted.
+
+<Table 
+headers={[ "Event", "Description" ]}
+data={[
+{
+event: "session_proposal",
+description: "Emitted by the dapp when it makes a session proposal",
+},
+{
+event: "session_connect",
+description: "Sent by the WalletConnect serve when the wallet approves the session proposal",
+},
+{
+event: "session_request",
+description: "Sent by the WalletConnect client when it wants to create a new session with the server.",
+},
+{
+event: "session_approve",
+description: "Sent by the wallet once the user approves the session request",
+},
+{
+event: "session_update",
+description: "Sent by the WalletConnect client when it wants to update an existing session with the server.",
+},
+{
+event: "session_delete",
+description: "Either the wallet or the dapp can emit this event when a session is disconnected",
+},
+{
+event: "session_event",
+description: "Sent by the WalletConnect client when it wants to emit an event to the server.",
+},
+{
+event: "session_ping",
+description: "Sent by the WalletConnect client to keep a session alive.",
+},
+{
+event: "session_expire",
+description: "Sent by the WalletConnect server when a session expires.",
+},
+{
+event: "session_extend",
+description: "Sent by the WalletConnect client when it wants to extend an existing session with the server.",
+},
+]}
+/>
+
+## Triggering Events
+
+To trigger one of the events from above, you generally need to call an action. Below are a list of methods and their associated events. This is not a full list of the function available, just the ones that emit an event.
+
+<Table 
+headers={[ "Method", "Event On", "Event Triggered" ]}
+data={[
+{
+methodSign: "connect",
+eventOn: "none",
+eventTriggered: "session_connect"
+},
+{
+methodSign: "pair",
+eventOn: "none",
+eventTriggered: "session_connect"
+},
+{
+methodSign: "approve",
+eventOn: "client.on('session_proposal')",
+eventTriggered: "session_approve"
+},
+{
+methodSign: "reject",
+eventOn: "none",
+eventTriggered: "session_rejected"
+},
+{
+methodSign: "update",
+eventOn: "none",
+eventTriggered: "session_updated"
+},
+{
+methodSign: "extend",
+eventOn: "client.on('session_extend')",
+eventTriggered: "session_extend"
+},
+{
+methodSign: "request",
+eventOn: "none",
+eventTriggered: "session_request"
+},
+{
+methodSign: "respond",
+eventOn: "client.on('session_request')",
+eventTriggered: "session_respond"
+},
+{
+methodSign: "ping",
+eventOn: "none",
+eventTriggered: "session_ping"
+},
+{
+methodSign: "emit",
+eventOn: "none",
+eventTriggered: "session_event"
+},
+{
+methodSign: "disconnect",
+eventOn: "none",
+eventTriggered: "session_delete"
+},
+{
+methodSign: "find",
+eventOn: "none",
+eventTriggered: "none"
+},
+{
+methodSign: "getPendingSessionRequests",
+eventOn: "none",
+eventTriggered: "none"
+},
+{
+methodSign: "getAll",
+eventOn: "none",
+eventTriggered: "none"
+},
+]}
+/>


### PR DESCRIPTION
Add documentation for Auth and Sign API covering:
- Available events
- How they are triggered

Note: Events that have `none` as `Event Triggered` will be removed once confirmed these methods do not emit an events.