### PR TITLE
fix(spec): corrects error code for Push `.userUnsubscribed` reason

### DIFF
--- a/docs/specs/clients/push/error-codes.md
+++ b/docs/specs/clients/push/error-codes.md
@@ -1,4 +1,3 @@
-
 # Error Codes
 
 ## INVALID
@@ -16,7 +15,7 @@ case .userRejected return 5000
 ## REASON
 
 ```sh
-case .userUnsubscribed return 5000
+case .userUnsubscribed return 6000
 ```
 
 ## FAILURE


### PR DESCRIPTION
To align with: https://github.com/WalletConnect/walletconnect-docs/blob/9bb84dfc3f84ba4dce0c67b81229e07feeffbcbd/docs/specs/clients/sign/error-codes.md#reason

Realised that we ended up with two `5000` codes being added yesterday, presumably a copy-paste mistake.