### PR TITLE
Remove namespaces.extension

### DIFF
--- a/docs/advanced/glossary.md
+++ b/docs/advanced/glossary.md
@@ -127,7 +127,7 @@ The dapp validates if the received proposal namespaces comply with the session n
       "eip155:137:0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb",
       "eip155:1:0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb"
     ],
-    "methods": ["eth_sign"]
+    "methods": ["eth_sign"],
     "events": ["accountsChanged"]
   },
   "cosmos": {

--- a/docs/advanced/glossary.md
+++ b/docs/advanced/glossary.md
@@ -105,14 +105,7 @@ A dapp sends a proposal namespace to the wallet for pairing. The proposal namesp
   "eip155": {
     "chains": ["eip155:137", "eip155:1"],
     "methods": ["eth_sign"],
-    "events": ["accountsChanged"],
-    "extensions": [
-      {
-        "chains": ["eip155:137"],
-        "method": ["personalSign"],
-        "events": ["chainChanged"]
-      }
-    ]
+    "events": ["accountsChanged"]
   },
   "cosmos": {
     "chains": ["cosmos:cosmoshub-4"],
@@ -121,8 +114,6 @@ A dapp sends a proposal namespace to the wallet for pairing. The proposal namesp
   }
 }
 ```
-
-The `extension` field is used to mention the *chain-exclusive parameters*. For example, let's say Polygon has a special method `personalSign` and an event `chainChanged` that is not available in Ethereum Mainnet. Hence, these special chain-exclusive parameters can be mentioned as extensions as stated in the above code snippet.
 
 ### Session namespaces
 The dapp validates if the received proposal namespaces comply with the session namespaces. If they comply, a session is established successfully and pairing is completed. If not, the session is not established and all the cached data related to the namespaces are deleted. The session namespace can also choose to provide access to more chains, methods or events that were not a part of the proposal namespaces.
@@ -136,15 +127,8 @@ The dapp validates if the received proposal namespaces comply with the session n
       "eip155:137:0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb",
       "eip155:1:0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb"
     ],
-    "methods": ["eth_sign"],
-    "events": ["accountsChanged"],
-    "extensions": [
-      {
-        "accounts": ["eip155:137:0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb"],
-        "method": ["personalSign"],
-        "events": ["chainChanged"]
-      }
-    ]
+    "methods": ["eth_sign"]
+    "events": ["accountsChanged"]
   },
   "cosmos": {
     "accounts": [

--- a/docs/javascript/sign/wallet-usage.md
+++ b/docs/javascript/sign/wallet-usage.md
@@ -79,11 +79,6 @@ signClient.on("session_proposal", (event) => {
           chains: string[];
           methods: string[];
           events: string[];
-          extension?: {
-            chains: string[];
-            methods: string[];
-            events: string[];
-          }[];
         }
       >;
       pairingTopic?: string;
@@ -151,30 +146,9 @@ namespaces: {
   eip155: {
     accounts: ["eip155:1:0x0000000000..., eip155:2:0x0000000000..."],
     methods: ["personal_sign", "eth_sendTransaction"],
-    events: ["accountsChanged"],
-    extension: [
-      {
-        accounts: ["eip155:2:0x0000000000..."],
-        methods: ["eth_sign"],
-        events: [],
-      },
-    ],
+    events: ["accountsChanged"]
   },
 };
-```
-
-### Extension
-
-The `extension` parameter is used to specify methods that are not shared by all the accounts/chains of the namespace. For example, chain A may have a special method that is not shared by chain B - in this case, we would create an extension that would only include chain B. Here's an example:
-
-```js
-extension: [
-  {
-    accounts: ["eip:137"],
-    methods: ["eth_sign"],
-    events: [],
-  },
-];
 ```
 
 ### Pairing with `uri`
@@ -198,14 +172,7 @@ const { topic, acknowledged } = await signClient.approve({
     eip155: {
       accounts: ["eip155:1:0x0000000000..."],
       methods: ["personal_sign", "eth_sendTransaction"],
-      events: ["accountsChanged"],
-      extension: [
-        {
-          accounts: ["eip:137"],
-          methods: ["eth_sign"],
-          events: [],
-        },
-      ],
+      events: ["accountsChanged"]
     },
   },
 });

--- a/docs/specs/clients/sign/data-structures.md
+++ b/docs/specs/clients/sign/data-structures.md
@@ -41,28 +41,14 @@ Session is a topic encrypted by a symmetric key derived using a key agreement es
     "<namespace_name>" : {
       "accounts": [string],
       "methods": [string],
-      "events": [string],
-      "extension": [ // optional
-        {
-          "accounts": [string],
-          "methods": [string],
-          "events": [string],
-        }
-      ]
+      "events": [string]
     }
   },
   "requiredNamespaces": {
     "<namespace_name>" : {
       "chains": [string],
       "methods": [string],
-      "events": [string],
-      "extension": [ // optional
-        {
-          "chains": [string],
-          "methods": [string],
-          "events": [string],
-        }
-      ]
+      "events": [string]
     }
   },
 }
@@ -89,14 +75,7 @@ Proposal is sent by the proposer client to be approved or rejected by the respon
     "<namespace_name>" : {
       "chains": [string],
       "methods": [string],
-      "events": [string],
-      "extension": [ // optional
-        {
-          "chains": [string],
-          "methods": [string],
-          "events": [string],
-        }
-      ]
+      "events": [string]
     }
   },
   "pairingTopic": string
@@ -145,14 +124,7 @@ Settelement is sent by the responder after approval and it's broadcasted right a
     "<namespace_name>" : {
       "accounts": [string],
       "methods": [string],
-      "events": [string],
-      "extension": [ // optional
-        {
-          "accounts": [string],
-          "methods": [string],
-          "events": [string],
-        }
-      ]
+      "events": [string]
     }
   },
   "expiry": Int64, // seconds

--- a/docs/specs/clients/sign/rpc-methods.md
+++ b/docs/specs/clients/sign/rpc-methods.md
@@ -48,14 +48,7 @@ Used to propose a session through topic A. Requires a success response with asso
     "<namespace_name>" : {
       "chains": [string],
       "methods": [string],
-      "events": [string],
-      "extension": [ // optional
-        {
-          "chains": [string],
-          "methods": [string],
-          "events": [string],
-        }
-      ]
+      "events": [string]
     }
   },
 }
@@ -107,14 +100,7 @@ Used to settle a session over topic B.
     "<namespace_name>" : {
       "accounts": [string],
       "methods": [string],
-      "events": [string],
-      "extension": [ // optional
-        {
-          "accounts": [string],
-          "methods": [string],
-          "events": [string],
-        }
-      ]
+      "events": [string]
     }
   },
   "expiry": Int64, // seconds
@@ -153,14 +139,7 @@ Used to update the namespaces of a session.
     "<namespace_name>" : {
       "accounts": [string],
       "methods": [string],
-      "events": [string],
-      "extension": [ // optional
-        {
-          "accounts": [string],
-          "methods": [string],
-          "events": [string],
-        }
-      ]
+      "events": [string]
     }
   }
 }

--- a/docs/specs/clients/sign/session-namespaces.md
+++ b/docs/specs/clients/sign/session-namespaces.md
@@ -1,7 +1,7 @@
 # Session Namespaces
 
 Let's say a dapp wants access to Ethereum Mainnet, Polygon, Cosmos Mainnet.
-It specifies the proposed execution environment for each blockchain in the form of namespaces. For example, for Ethereum Mainnet and Polygon, it requires: `eth_sign` method and `accountsChanged` event, and, for Cosmos Mainnet, it requires: `cosmos_signDirect` method and `someCosmosEvent` event. Let's say that Polygon also has a special method `personalSign` and an event `chainChanged` not available in Ethereum Mainnet. The Dapp can require chain-exclusive parameters via the `extensions` field.
+It specifies the proposed execution environment for each blockchain in the form of namespaces. For example, for Ethereum Mainnet and Polygon, it requires: `eth_sign` method and `accountsChanged` event, and, for Cosmos Mainnet, it requires: `cosmos_signDirect` method and `someCosmosEvent` event. Let's say that Polygon also has a special method `personalSign` and an event `chainChanged` not available in Ethereum Mainnet.
 
 ## Example Proposal Namespaces request
 
@@ -10,14 +10,7 @@ It specifies the proposed execution environment for each blockchain in the form 
   "eip155": {
     "chains": ["eip155:137", "eip155:1"],
     "methods": ["eth_sign"],
-    "events": ["accountsChanged"],
-    "extensions": [
-      {
-        "chains": ["eip155:137"],
-        "method": ["personalSign"],
-        "events": ["chainChanged"]
-      }
-    ]
+    "events": ["accountsChanged"]
   },
   "cosmos": {
     "chains": ["cosmos:cosmoshub-4"],
@@ -41,14 +34,7 @@ If the Wallet (or the user) does NOT approve the session, then it is rejected. O
       "eip155:1:0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb"
     ],
     "methods": ["eth_sign"],
-    "events": ["accountsChanged"],
-    "extensions": [
-      {
-        "accounts": ["eip155:137:0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb"],
-        "method": ["personalSign"],
-        "events": ["chainChanged"]
-      }
-    ]
+    "events": ["accountsChanged"]
   },
   "cosmos": {
     "accounts": [
@@ -155,95 +141,7 @@ Throw Error Code: `case .unsupportedChains: return 5100`
 
 ---
 
-### 1.5. Extension MUST NOT have chains empty
-
-Requested Proposal Namespaces:
-
-```json
-{
-  "eip155": {
-    "chains": ["eip155:1", "eip155:137"],
-    "methods": ["personalSign"],
-    "events": [],
-    "extensions": [
-      {
-        "chains": [],
-        "methods": ["eth_getAccounts"],
-        "events": []
-      }
-    ]
-  }
-}
-```
-
-Is valid?: No
-
-Note: Proposal namespace extension doesn't have any chains, hence it's invalid
-
-Throw Message: `Chains must not be empty`
-Throw Error Code: `case .unsupportedChains: return 5100`
-
----
-
-### 1.6. Extension methods field is REQUIRED
-
-Requested Proposal Namespaces:
-
-```json
-{
-  "eip155": {
-    "chains": ["eip155:1", "eip155:137", "eip155:10"],
-    "methods": ["personalSign"],
-    "events": [],
-    "extensions": [
-      {
-        "chains": ["eip155:1"],
-        "events": ["chainChanged"]
-      }
-    ]
-  }
-}
-```
-
-Is valid?: No
-
-Note: Extension is missing `methods` field.
-
-Throw Message: `Methods field is missing`
-Throw Error Code: `case .unsupportedMethods: return 5101`
-
----
-
-### 1.7. Extension events field is REQUIRED
-
-Requested Proposal Namespaces:
-
-```json
-{
-  "eip155": {
-    "chains": ["eip155:1", "eip155:137", "eip155:10"],
-    "methods": ["personalSign"],
-    "events": [],
-    "extensions": [
-      {
-        "chains": ["eip155:137"],
-        "methods": ["eth_getAccounts"]
-      }
-    ]
-  }
-}
-```
-
-Is valid?: No
-
-Note: Extension is missing `events` field.
-
-Throw Message: `Events field is missing`
-Throw Error Code: `case .unsupportedEvents: return 5102`
-
----
-
-### 1.8. Namespace key must comply with CAIP-2 specification
+### 1.5. Namespace key must comply with CAIP-2 specification
 
 Requested Proposal Namespaces:
 
@@ -271,7 +169,7 @@ Throw Error Code: `case .unsupportedNamespaceKey: return 5104`
 
 ---
 
-### 1.9. All namespaces MUST be valid
+### 1.6. All namespaces MUST be valid
 
 Requested Proposal Namespaces:
 
@@ -299,7 +197,7 @@ Throw Error Code should be the frist one caught
 
 ---
 
-### 1.10. Proposal namespaces MAY be empty
+### 1.7. Proposal namespaces MAY be empty
 
 Requested Proposal Namespaces:
 
@@ -662,47 +560,7 @@ Throw Error Code: `case .userRejected return 5000`
 
 ---
 
-### 2.10. Extensions MAY be merged into namespace
-
-Requested Proposal Namespaces:
-
-```json
-{
-  "eip155": {
-    "chains": ["eip155:137", "eip155:1"],
-    "methods": ["eth_sign"],
-    "events": ["accountsChanged"],
-    "extensions": [
-      {
-        "chains": ["eip155:137"],
-        "methods": ["personalSign"],
-        "events": []
-      }
-    ]
-  }
-}
-```
-
-Received Session Namespaces:
-
-```json
-{
-  "eip155": {
-    "accounts": [
-      "eip155:1:0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb",
-      "eip155:137:0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb"
-    ],
-    "methods": ["eth_sign", "personalSign"],
-    "events": ["accountsChanged"]
-  }
-}
-```
-
-Is valid?: Yes
-
----
-
-### 2.11. Session Namespaces MUST approve all events
+### 2.10. Session Namespaces MUST approve all events
 
 Requested Proposal Namespaces:
 
@@ -737,139 +595,3 @@ Throw Error Code: `case .userRejectedEvents: return 5003`
 
 ---
 
-### 2.12. Session Namespaces extensions MAY extend methods and events of Proposal Namespaces extensions
-
-Requested Proposal Namespaces:
-
-```json
-{
-  "eip155": {
-    "chains": ["eip155:1", "eip155:137"],
-    "methods": [],
-    "events": ["chainChanged"],
-    "extensions": [
-      {
-        "chains": ["eip155:137"],
-        "methods": ["eth_sign"],
-        "events": []
-      }
-    ]
-  }
-}
-```
-
-Received Session Namespaces:
-
-```json
-{
-  "eip155": {
-    "accounts": [
-      "eip155:1:0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb",
-      "eip155:137:0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb"
-    ],
-    "methods": [],
-    "events": ["chainChanged"],
-    "extensions": [
-      {
-        "accounts": ["eip155:137:0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb"],
-        "methods": ["eth_sign", "personalSign"],
-        "events": ["accountsChanged"]
-      }
-    ]
-  }
-}
-```
-
-Is valid?: Yes
-
----
-
-### 2.13. Session Namespaces extensions MAY contain accounts from chains not defined in Proposal Namespaces extensions
-
-Requested Proposal Namespaces:
-
-```json
-{
-  "eip155": {
-    "chains": ["eip155:1", "eip155:137"],
-    "methods": ["eth_sign"],
-    "events": ["accountsChanged"],
-    "extensions": [
-      {
-        "chains": ["eip155:137"],
-        "methods": ["personalSign"],
-        "events": ["chainChanged"]
-      }
-    ]
-  }
-}
-```
-
-Received Session Namespaces:
-
-```json
-{
-  "eip155": {
-    "accounts": [
-      "eip155:1:0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb",
-      "eip155:137:0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb"
-    ],
-    "methods": ["eth_sign"],
-    "events": ["accountsChanged"],
-    "extensions": [
-      {
-        "accounts": [
-          "eip155:137:0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb",
-          "eip155:42:0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb"
-        ],
-        "methods": ["personalSign"],
-        "events": ["chainChanged"]
-      }
-    ]
-  }
-}
-```
-
-Is valid?: Yes
-
----
-
-### 2.14. Session Namespaces MAY add extensions not defined in Proposal Namespaces extensions
-
-Requested Proposal Namespaces:
-
-```json
-{
-  "eip155": {
-    "chains": ["eip155:1", "eip155:137"],
-    "methods": ["eth_sign"],
-    "events": ["accountsChanged"]
-  }
-}
-```
-
-Received Session Namespaces:
-
-```json
-{
-  "eip155": {
-    "accounts": [
-      "eip155:1:0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb",
-      "eip155:137:0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb"
-    ],
-    "methods": ["eth_sign"],
-    "events": ["accountsChanged"],
-    "extensions": [
-      {
-        "accounts": ["eip155:137:0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb"],
-        "methods": ["personalSign"],
-        "events": ["chainChanged"]
-      }
-    ]
-  }
-}
-```
-
-Is valid?: Yes
-
----

--- a/docs/swift/sign/dapp-usage.md
+++ b/docs/swift/sign/dapp-usage.md
@@ -41,7 +41,7 @@ Following publishers are available to subscribe:
 ```Swift
 let methods: Set<String> = ["eth_sendTransaction", "personal_sign", "eth_signTypedData"]
 let blockchains: Set<Blockchain> = [Blockchain("eip155:1")!, Blockchain("eip155:137")!]
-let namespaces: [String: ProposalNamespace] = ["eip155": ProposalNamespace(chains: blockchains, methods: methods, events: [], extensions: nil)]
+let namespaces: [String: ProposalNamespace] = ["eip155": ProposalNamespace(chains: blockchains, methods: methods, events: []]
 ``` 
 To learn more on namespaces, check out our [specs](../../specs/clients/sign/session-namespaces).
 


### PR DESCRIPTION
Removed all instances of `extension` when pertaining to an additional object in `namespaces`.