### PR TITLE
Fix spelling for unsubscribe method

### DIFF
--- a/docs/web3modal/html-js/actions.md
+++ b/docs/web3modal/html-js/actions.md
@@ -28,7 +28,7 @@ web3modal.closeModal();
 Subscribe or unsubscribe from modal's state.
 
 ```js
-const usnubscribe = web3modal.subscribeModal((newState) =>
+const unsubscribe = web3modal.subscribeModal((newState) =>
   console.log(newState)
 );
 unsubscribe();
@@ -55,7 +55,7 @@ web3modal.getSelectedChain();
 Subscribe or unsubscribe from selected chain changes. (Only subscribes in scope of Web3Modal, not wagmi)
 
 ```js
-const usnubscribe = web3modal.subscribeSelectedChain((newState) =>
+const unsubscribe = web3modal.subscribeSelectedChain((newState) =>
   console.log(newState)
 );
 unsubscribe();


### PR DESCRIPTION
minor correction made for the spelling of unsubscribe in the unsubscribe() method