### PR TITLE
Add get pendingthreads

### DIFF
--- a/docs/specs/clients/chat/client-api.md
+++ b/docs/specs/clients/chat/client-api.md
@@ -66,6 +66,11 @@ abstract class Client {
   public abstract getThreads(params: {
     account: string;
   }): Promise<Map<string, Thread>>;
+  
+  // returns all pending threads matching an account / returns map of threads indexed by topic
+  public abstract getPendingThreads(params: {
+    account: string;
+  }): Promise<Map<string, PendingThread>>;
 
   // returns all messages matching a thread's topic / returns array of messages
   public abstract getMessages(params: {

--- a/docs/specs/clients/chat/client-api.md
+++ b/docs/specs/clients/chat/client-api.md
@@ -19,6 +19,7 @@ abstract class Client {
   }): Promise<string>;
 
   // sends a chat invite to peer account / returns an invite id
+  // Stores the invite in a separate store for pendingThreads
   public abstract invite(params: {
     account: string;
     invite: Invite;
@@ -70,7 +71,7 @@ abstract class Client {
   // returns all pending threads matching an account / returns map of threads indexed by topic
   public abstract getPendingThreads(params: {
     account: string;
-  }): Promise<Map<string, PendingThread>>;
+  }): Promise<Map<string, PendingOrRejectedThread>>;
 
   // returns all messages matching a thread's topic / returns array of messages
   public abstract getMessages(params: {

--- a/docs/specs/clients/chat/data-structures.md
+++ b/docs/specs/clients/chat/data-structures.md
@@ -39,6 +39,17 @@ An array of Messages is returned on `getMessages(params: {topic: string;})`
 }
 ```
 
+## PendingOrRejectedThread
+
+```jsonc
+{
+  "topic": string | undefined,
+  "selfAccount": string,
+  "peerAccount": string,
+  "status": 'pending' | 'rejected'
+}
+```
+
 ## Thread
 
 A map of type `Map<string, Thread>` is returned on `getThreads(params: {account: string;}`. Topic is the key of the map.


### PR DESCRIPTION
# Changes
- Add `PendingOrRejectedThread` structure
- When an `invite` is sent, the proposed thread can be accessed by `getPendingThreads()`, should have `pending` status
- When a `reject` is received, the proposed thread can still be accessed but should now have `rejected` status

# Reasoning
UIs will likely want to show pending threads, or invites that were declined. 