### PR TITLE
feat(explorer-api): document standards query param

### DIFF
--- a/docs/cloud/explorer.md
+++ b/docs/cloud/explorer.md
@@ -28,6 +28,7 @@ By default listings endpoints return all data for provided type. You can use fol
 | chains      |           | Returns listings that support at least one of the provided chains<br/>(e.g. `?chains=eip155:1,eip155:137`)               |
 | platforms   |           | Returns listings that support at least one of the provided platforms<br/>(e.g. `?platforms=ios,android,mac`)             |
 | sdks        |           | Returns listings that support at least one of the provided WalletConnect SDKs<br/>(e.g. `?sdks=sign_v1,sign_v2,auth_v1`) |
+| standards   |           | Returns listings that support at least one of the provided standards<br/>(e.g. `?standards=eip-712,eip-3085`)                |
 | ~~version~~ |           | Deprecated - replaced by `sdks` param. Specifies supported Sign version (1 or 2)                                         |
 
 #### `GET /v3/wallets`


### PR DESCRIPTION
Closes #414

### Context

Enables API users to filter listings based on standards with the following pattern `standard_prefix-standard_id`
For example, to query dapp listings that support EIP712 or EIP3085:

`/v3/dapps?projectId=PID&standards=eip-712,eip-3085`