### PR TITLE
fix(specs): fixes wrong ID for CAIP-74 references and links to CAIP spec

### DIFF
--- a/docs/specs/clients/auth/data-structures.md
+++ b/docs/specs/clients/auth/data-structures.md
@@ -16,6 +16,7 @@ interface RequestParams {
   resources?: string[];
 }
 ```
+
 ## Respond Params
 
 ```typescript
@@ -58,7 +59,7 @@ interface PendingRequest {
 }
 ```
 
-## Cacao Header (CAIP-70)
+## Cacao Header ([CAIP-74](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-74.md))
 
 ```typescript
 interface CacaoHeader {
@@ -66,7 +67,7 @@ interface CacaoHeader {
 }
 ```
 
-## Cacao Payload (CAIP-70)
+## Cacao Payload ([CAIP-74](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-74.md))
 
 ```typescript
 interface CacaoPayload {
@@ -84,7 +85,7 @@ interface CacaoPayload {
 }
 ```
 
-## Cacao Signature (CAIP-70)
+## Cacao Signature ([CAIP-74](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-74.md))
 
 ```typescript
 interface CacaoSignature {
@@ -94,7 +95,7 @@ interface CacaoSignature {
 }
 ```
 
-## Cacao (CAIP-70)
+## Cacao ([CAIP-74](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-74.md))
 
 ```typescript
 interface Cacao {


### PR DESCRIPTION
## Context

* Discord user `Moneta#7795` gracefully pointed out that the CAIP ID number in the spec is incorrect when referencing the CACAO standard.
* Also adds links to the CAIP spec itself.