### PR TITLE
Remove Prompt Flag

### DIFF
--- a/docs/specs/clients/auth/rpc-methods.md
+++ b/docs/specs/clients/auth/rpc-methods.md
@@ -59,7 +59,6 @@ When DApp is setting `expiry` params, client should insure that Relay Publish pa
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 86400    |
-| Prompt  | true     |
 | Tag     | 3000     |
 
 ```
@@ -77,7 +76,6 @@ When DApp is setting `expiry` params, client should insure that Relay Publish pa
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 86400    |
-| Prompt  | false    |
 | Tag     | 3001     |
 ```
 

--- a/docs/specs/clients/chat/rpc-methods.md
+++ b/docs/specs/clients/chat/rpc-methods.md
@@ -36,7 +36,6 @@ Used to invite a peer through topic I. Requires a success response with associat
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 2592000  |
-| Prompt  | true     |
 | Tag     | 2000     |
 
 ```
@@ -52,7 +51,6 @@ Used to invite a peer through topic I. Requires a success response with associat
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 2592000  |
-| Prompt  | false    |
 | Tag     | 2001     |
 ```
 
@@ -74,7 +72,6 @@ Used to send a message to its peer through topic T.
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 2592000  |
-| Prompt  | true     |
 | Tag     | 2002     |
 ```
 
@@ -89,7 +86,6 @@ Used to send a message to its peer through topic T.
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 2592000  |
-| Prompt  | false    |
 | Tag     | 2003     |
 ```
 
@@ -108,7 +104,6 @@ Used to signal to a peer that a chat thread is being left.
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 2592000  |
-| Prompt  | true     |
 | Tag     | 2004     |
 ```
 
@@ -121,7 +116,6 @@ true
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 2592000  |
-| Prompt  | false    |
 | Tag     | 2005     |
 ```
 
@@ -140,7 +134,6 @@ Used to evaluate if peer is currently online. Timeout at 30 seconds
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 30       |
-| Prompt  | false    |
 | Tag     | 2006     |
 ```
 
@@ -153,6 +146,5 @@ true
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 30       |
-| Prompt  | false    |
 | Tag     | 2007     |
 ```

--- a/docs/specs/clients/core/relay/relay-client-api.md
+++ b/docs/specs/clients/core/relay/relay-client-api.md
@@ -56,7 +56,6 @@ The policy object defines the policy's parameters.
 {
     "ttl" : seconds,
     "tag" : number, // Optional / default = 0
-    "prompt" : boolean // Optional / default = false
 }
 ```
 

--- a/docs/specs/clients/push/rpc-methods.md
+++ b/docs/specs/clients/push/rpc-methods.md
@@ -38,7 +38,6 @@ Used to request push subscription to a peer through topic P. Response is expecte
 | IRN     |          |
 | ------- | -------- | 
 | TTL     | 86400    |
-| Prompt  | true     |
 | Tag     | 4000     |
 
 ```
@@ -54,7 +53,6 @@ Used to request push subscription to a peer through topic P. Response is expecte
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 86400    |
-| Prompt  | false    |
 | Tag     | 4001     |
 ```
 
@@ -80,7 +78,6 @@ Used to publish a notification message to a peer through topic P. Response is ex
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 86400    |
-| Prompt  | true     |
 | Tag     | 4002     |
 
 ```
@@ -94,7 +91,6 @@ true
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 86400    |
-| Prompt  | false    |
 | Tag     | 4003     |
 
 ```
@@ -114,7 +110,6 @@ Used to inform the peer to close and delete a push subscription. The reason fiel
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 86400    |
-| Prompt  | true     |
 | Tag     | 4004     |
 ```
 
@@ -126,5 +121,4 @@ true
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 86400    |
-| Prompt  | false    |
 | Tag     | 4005     |

--- a/docs/specs/clients/sign/rpc-methods.md
+++ b/docs/specs/clients/sign/rpc-methods.md
@@ -56,7 +56,6 @@ Used to propose a session through topic A. Requires a success response with asso
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 300      |
-| Prompt  | true     |
 | Tag     | 1100     |
 ```
 
@@ -75,7 +74,6 @@ Used to propose a session through topic A. Requires a success response with asso
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 300      |
-| Prompt  | false    |
 | Tag     | 1101     |
 ```
 
@@ -109,7 +107,6 @@ Used to settle a session over topic B.
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 300      |
-| Prompt  | false    |
 | Tag     | 1102     |
 ```
 
@@ -122,7 +119,6 @@ true
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 300      |
-| Prompt  | false    |
 | Tag     | 1103     |
 ```
 
@@ -147,7 +143,6 @@ Used to update the namespaces of a session.
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 86400    |
-| Prompt  | false    |
 | Tag     | 1104     |
 ```
 
@@ -160,7 +155,6 @@ true
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 86400    |
-| Prompt  | false    |
 | Tag     | 1105     |
 ```
 
@@ -181,7 +175,6 @@ Used to extend the lifetime of a session.
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 86400    |
-| Prompt  | false    |
 | Tag     | 1106     |
 ```
 
@@ -194,7 +187,6 @@ true
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 86400    |
-| Prompt  | false    |
 | Tag     | 1107     |
 ```
 
@@ -233,7 +225,6 @@ When DApp is setting `expiry` params, client should insure that Relay Publish pa
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 300      |
-| Prompt  | true     |
 | Tag     | 1108     |
 ```
 
@@ -246,7 +237,6 @@ true
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 300      |
-| Prompt  | false    |
 | Tag     | 1109     |
 ```
 
@@ -267,7 +257,6 @@ true
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 300      |
-| Prompt  | true     |
 | Tag     | 1110     |
 ```
 
@@ -280,7 +269,6 @@ true
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 300      |
-| Prompt  | false    |
 | Tag     | 1111     |
 ```
 
@@ -300,7 +288,6 @@ Used to inform the peer to close and delete a session. The reason field should b
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 86400    |
-| Prompt  | false    |
 | Tag     | 1112     |
 ```
 
@@ -313,7 +300,6 @@ true
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 86400    |
-| Prompt  | false    |
 | Tag     | 1113     |
 ```
 
@@ -332,7 +318,6 @@ Used to evaluate if peer is currently online. Timeout at 30 seconds
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 30       |
-| Prompt  | false    |
 | Tag     | 1114     |
 ```
 
@@ -345,6 +330,5 @@ true
 | IRN     |          |
 | ------- | -------- |
 | TTL     | 30       |
-| Prompt  | false    |
 | Tag     | 1115     |
 ```

--- a/docs/specs/servers/relay/relay-server-rpc.md
+++ b/docs/specs/servers/relay/relay-server-rpc.md
@@ -12,7 +12,6 @@ The following definitions are shared concepts across all JSON-RPC methods for th
 - **message** - a plaintext message to be relayed to any subscribers on the topic.
 - **ttl** - a storage duration for the message to be cached server-side in **seconds** (aka time-to-live).
 - **tag** - a label that identifies what type of message is sent based on the rpc method used.
-- **prompt** - a flag that identifies whether the server should trigger a notification webhook to a client through a push server.
 - **id** - a unique identifier for each subscription targeting a topic.
 
 ## Publish payload
@@ -29,7 +28,6 @@ Used when a client publishes a message to a server.
     "message" : string,
     "ttl" : seconds,
     "tag" : number, // optional / default = 0
-    "prompt" : boolean, // optional / default = false
   }
 }
 ```


### PR DESCRIPTION
Following the conversation at the Push weekly meeting. The prompt flag is redundant now that tags are used instead