### PR TITLE
add FAQs around self hosting

### DIFF
--- a/docs/advanced/faq.md
+++ b/docs/advanced/faq.md
@@ -38,21 +38,19 @@ const signClient = await SignClient.init({
 
 </details>
 
-<details className="box faq"><summary className="faq-question">How can we use a custom relay for our bridge without a WC URI parameter for the host?</summary>
+<details className="box faq"><summary className="faq-question">How can we use a custom relay for our bridge without a WC URI parameter as the host?</summary>
 <p className="faq-answer">
 
- A custom URI parameter can be utilized during testing, however it is not recommended for use in a production environment.
+You are more than welcome to utilize a custom URI parameter during testing. However, it is currently not recommended for use in a production environment. 
 
 </p>
 
 </details>
 
-<details className="box faq"><summary className="faq-question">Why is self-hosting of RPC nodes not currently an option and what are the plans for decentralization?</summary>
+<details className="box faq"><summary className="faq-question">Why is self-hosting RPC nodes not an option at this time? Are there plans to make this possible in the future?</summary>
 <p className="faq-answer">
 
-We acknowledge the concerns around centralization and the desire for developers to self-host their own RPC nodes. However, at this time, we will not be able to offer that option. We understand that in the web3 space, decentralization is a key concern. We have chosen a more pragmatic solution and have observed that currently, the industry standard is the use of third-party RPC services.
-
-This summer, we will be launching a permissioned network available to a select group of partners. This will allow for more decentralization of nodes and will provide additional options for developers.
+We understand the desire for developers to self-host their own RPC nodes. We share this vision, and have embarked on a decentralization roadmap in order to achieve this. This summer, we will launch a permissioned network and invite a select group of partners to participate in this crucial first phase. Our objective is to make self-hosting RPC nodes a reality with the creation of the decentralized WalletConnect Network, and we appreciate your patience as we progress in this enormous mission. 
 
 </p>
 

--- a/docs/advanced/faq.md
+++ b/docs/advanced/faq.md
@@ -21,15 +21,15 @@ No, the bridge servers are v1 only.
 
 </details>
 
-<details className="box faq"><summary className="faq-question">The default RPC endpoint is blocked. How can I get around this?</summary>
+<details className="box faq"><summary className="faq-question">The default relay endpoint is blocked. How can I get around this?</summary>
 <p className="faq-answer">
 
-When initializing `signClient`, you can set `rpcUrl` to `wss://relay.walletconnect.com`. 
+When initializing `signClient`, you can set `relayUrl` to `wss://relay.walletconnect.org`. 
 
 ```js
 const signClient = await SignClient.init({
   projectId: "<YOUR PROJECT ID>",
-  relayUrl: "wss://relay.walletconnect.com",
+  relayUrl: "wss://relay.walletconnect.org",
   metadata: {},
 });
 ```
@@ -47,10 +47,10 @@ You are more than welcome to utilize a custom URI parameter during testing. Howe
 
 </details>
 
-<details className="box faq"><summary className="faq-question">Why is self-hosting RPC nodes not an option at this time? Are there plans to make this possible in the future?</summary>
+<details className="box faq"><summary className="faq-question">Why is self-hosting not an option at this time? Are there plans to make this possible in the future?</summary>
 <p className="faq-answer">
 
-We understand the desire for developers to self-host their own RPC nodes. We share this vision, and have embarked on a decentralization roadmap in order to achieve this. This summer, we will launch a permissioned network and invite a select group of partners to participate in this crucial first phase. Our objective is to make self-hosting RPC nodes a reality with the creation of the decentralized WalletConnect Network, and we appreciate your patience as we progress in this enormous mission. 
+We understand the desire for developers to self-host their own relay. We share this vision, and have embarked on a decentralization roadmap in order to achieve this. This summer, we will launch a permissioned network and invite a select group of partners to participate in this crucial first phase. Our objective is to make self-hosting relay a reality with the creation of the decentralized WalletConnect Network, and we appreciate your patience as we progress in this enormous mission. 
 
 </p>
 

--- a/docs/advanced/faq.md
+++ b/docs/advanced/faq.md
@@ -29,10 +29,30 @@ When initializing `signClient`, you can set `rpcUrl` to `relay.walletconnect.org
 ```js
 const signClient = await SignClient.init({
   projectId: "<YOUR PROJECT ID>",
-  relayUrl: "walletconnect.org",
+  relayUrl: "relay.walletconnect.org",
   metadata: {},
 });
 ```
+
+</p>
+
+</details>
+
+<details className="box faq"><summary className="faq-question">How can we use a custom relay for our bridge without a WC URI parameter for the host?</summary>
+<p className="faq-answer">
+
+ A custom URI parameter can be utilized during testing, however it is not recommended for use in a production environment.
+
+</p>
+
+</details>
+
+<details className="box faq"><summary className="faq-question">Why is self-hosting of RPC nodes not currently an option and what are the plans for decentralization?</summary>
+<p className="faq-answer">
+
+We acknowledge the concerns around centralization and the desire for developers to self-host their own RPC nodes. However, at this time, we will not be able to offer that option. We understand that in the web3 space, decentralization is a key concern. We have chosen a more pragmatic solution and have observed that currently, the industry standard is the use of third-party RPC services.
+
+This summer, we will be launching a permissioned network available to a select group of partners. This will allow for more decentralization of nodes and will provide additional options for developers.
 
 </p>
 

--- a/docs/advanced/faq.md
+++ b/docs/advanced/faq.md
@@ -24,12 +24,12 @@ No, the bridge servers are v1 only.
 <details className="box faq"><summary className="faq-question">The default RPC endpoint is blocked. How can I get around this?</summary>
 <p className="faq-answer">
 
-When initializing `signClient`, you can set `rpcUrl` to `relay.walletconnect.org`. 
+When initializing `signClient`, you can set `rpcUrl` to `wss://relay.walletconnect.com`. 
 
 ```js
 const signClient = await SignClient.init({
   projectId: "<YOUR PROJECT ID>",
-  relayUrl: "relay.walletconnect.org",
+  relayUrl: "wss://relay.walletconnect.com",
   metadata: {},
 });
 ```


### PR DESCRIPTION
Added two FAQs
- How can we use a custom relay for our bridge without a WC URI parameter as the host?
- Why is self-hosting RPC nodes not an option at this time? Are there plans to make this possible in the future?

Other Update
- Updated `relayUrl` to include `wss:relay.` prefix

Proof read by Linda.