### PR TITLE
Match cosmjs interface and fix intent

### DIFF
--- a/docs/advanced/rpc-reference/cosmos-rpc.md
+++ b/docs/advanced/rpc-reference/cosmos-rpc.md
@@ -25,22 +25,22 @@ This method returns an array of key pairs available to sign from the wallet mapp
 ```javascript
 // Request
 {
-  "id": 1,
-  "jsonrpc": "2.0",
-  "method": "cosmos_getAccounts",
-  "params": {}
+    "id": 1,
+    "jsonrpc": "2.0",
+    "method": "cosmos_getAccounts",
+    "params": {}
 }
 
 // Result
 {
-  "id": 1,
-  "jsonrpc": "2.0",
-  "result":  [
-      {
-        "algo": "secp256k1",
-        "address": "cosmos1sguafvgmel6f880ryvq8efh9522p8zvmrzlcrq",
-        "pubkey": "0204848ceb8eafdf754251c2391466744e5a85529ec81ae6b60a187a90a9406396"
-      }
+    "id": 1,
+    "jsonrpc": "2.0",
+    "result":  [
+        {
+            "algo": "secp256k1",
+            "address": "cosmos1sguafvgmel6f880ryvq8efh9522p8zvmrzlcrq",
+            "pubkey": "AgSEjOuOr991QlHCORRmdE5ahVKeyBrmtgoYepCpQGOW"
+        }
     ]
 }
 ```
@@ -62,7 +62,11 @@ This method returns a signature for the provided document to be signed targeting
 ### Returns
 
     1. `Object` - Signing parameters:
-    	1.1. `signature` : `STRING` -  corresponding signature for signed documented
+    	1.1. `signature` : `Object` -  corresponding signature for signed documented
+            1.1.1. `pub_key` : `Object` - public key for keypair
+                1.1.1.1: `type` : `STRING` - type of public key
+                1.1.1.2: `value` : `STRING` - value of public key
+            1.1.2. `signature`: `STRING` - corresponding signature for signed documented
     	1.2. `signed` : `Object` - Signed document:
     		1.2.2. `chainId` : `STRING` - identifier of blockchain
     		1.2.1. `accountNumber` : `STRING` - blockchain account number
@@ -74,33 +78,39 @@ This method returns a signature for the provided document to be signed targeting
 ```javascript
 // Request
 {
-  "id": 1,
-  "jsonrpc": "2.0",
-  "method": "cosmos_signDirect",
-  "params": {
-		"signerAddress": "cosmos1sguafvgmel6f880ryvq8efh9522p8zvmrzlcrq",
-		"signDoc":  {
-      "chainId": "cosmoshub-4",
-      "accountNumber": "1"
-      "authInfoBytes": "0a0a0a0012040a020801180112130a0d0a0575636f736d12043230303010c09a0c",
-      "bodyBytes": "0a90010a1c2f636f736d6f732e62616e6b2e763162657461312e4d736753656e6412700a2d636f736d6f7331706b707472653766646b6c366766727a6c65736a6a766878686c63337234676d6d6b38727336122d636f736d6f7331717970717870713971637273737a673270767871367273307a716733797963356c7a763778751a100a0575636f736d120731323334353637",
-    },
-	}
+    "id": 1,
+    "jsonrpc": "2.0",
+    "method": "cosmos_signDirect",
+    "params": {
+        "signerAddress": "cosmos1sguafvgmel6f880ryvq8efh9522p8zvmrzlcrq",
+        "signDoc":  {
+            "chainId": "cosmoshub-4",
+            "accountNumber": "1"
+            "authInfoBytes": "CgoKABIECgIIARgBEhMKDQoFdWNvc20SBDIwMDAQwJoM",
+            "bodyBytes": "CpABChwvY29zbW9zLmJhbmsudjFiZXRhMS5Nc2dTZW5kEnAKLWNvc21vczFwa3B0cmU3ZmRrbDZnZnJ6bGVzamp2aHhobGMzcjRnbW1rOHJzNhItY29zbW9zMXF5cHF4cHE5cWNyc3N6ZzJwdnhxNnJzMHpxZzN5eWM1bHp2N3h1GhAKBXVjb3NtEgcxMjM0NTY3"
+        }
+    }
 }
 
 // Result
 {
-  "id": 1,
-  "jsonrpc": "2.0",
-  "result":  {
-		"signature": "2d5b65f75c5baf109347ae37459330d3cb87577b51e5a2f8ea232256700575656869024dffe8e96ece863f238e060656ea75a576207f5b11a630ca041e80ae75",
-		"signDoc": {
-      "chainId": "cosmoshub-4",
-      "accountNumber": "1"
-      "authInfoBytes": "0a0a0a0012040a020801180112130a0d0a0575636f736d12043230303010c09a0c",
-      "bodyBytes": "0a90010a1c2f636f736d6f732e62616e6b2e763162657461312e4d736753656e6412700a2d636f736d6f7331706b707472653766646b6c366766727a6c65736a6a766878686c63337234676d6d6b38727336122d636f736d6f7331717970717870713971637273737a673270767871367273307a716733797963356c7a763778751a100a0575636f736d120731323334353637",
+    "id": 1,
+    "jsonrpc": "2.0",
+    "result":  {
+        "signature": {
+            "pub_key": {
+                "type": "tendermint/PubKeySecp256k1",
+                "value": "AgSEjOuOr991QlHCORRmdE5ahVKeyBrmtgoYepCpQGOW"
+            },
+            "signature": "AnTrXtS2lr9CBwhTpRa8ZlKcVR9PeIXGaTpvodyJU05QvRKVjIkQfOZl5JhdkfxCY+a6rhwCOYVcbKQTJlMw4w=="
+        },
+        "signDoc": {
+            "chainId": "cosmoshub-4",
+            "accountNumber": "1"
+            "authInfoBytes": "CgoKABIECgIIARgBEhMKDQoFdWNvc20SBDIwMDAQwJoM",
+            "bodyBytes": "CpABChwvY29zbW9zLmJhbmsudjFiZXRhMS5Nc2dTZW5kEnAKLWNvc21vczFwa3B0cmU3ZmRrbDZnZnJ6bGVzamp2aHhobGMzcjRnbW1rOHJzNhItY29zbW9zMXF5cHF4cHE5cWNyc3N6ZzJwdnhxNnJzMHpxZzN5eWM1bHp2N3h1GhAKBXVjb3NtEgcxMjM0NTY3"
+        }
     }
-	}
 }
 ```
 
@@ -131,7 +141,11 @@ This method returns a signature for the provided document to be signed targeting
 ### Returns
 
     1. `Object` - Signing parameters:
-    	1.1. `signature` : `STRING` -  corresponding signature for signed documented
+    	1.1. `signature` : `Object` -  corresponding signature for signed documented
+            1.1.1. `pub_key` : `Object` - public key for keypair
+                1.1.1.1: `type` : `STRING` - type of public key
+                1.1.1.2: `value` : `STRING` - value of public key
+            1.1.2. `signature`: `STRING` - corresponding signature for signed documented
     	1.2. `signed` : `Object` - Signed document:
     		1.2.2. `chain_id` : `STRING` - identifier of blockchain
     		1.2.1. `account_number` : `STRING` - blockchain account number
@@ -153,36 +167,42 @@ This method returns a signature for the provided document to be signed targeting
 ```javascript
 // Request
 {
-  "id": 1,
-  "jsonrpc": "2.0",
-  "method": "cosmos_signAmino",
-  "params": {
-		"signerAddress": "cosmos1sguafvgmel6f880ryvq8efh9522p8zvmrzlcrq",
-		"signDoc":   {
-      "chain_id": "foochain",
-      "account_number": "7",
-      "sequence": "54"
-      "memo": "hello, world",
-      "msgs": [],
-      "fee": { "amount": [], "gas": "23" },
+    "id": 1,
+    "jsonrpc": "2.0",
+    "method": "cosmos_signAmino",
+    "params": {
+        "signerAddress": "cosmos1sguafvgmel6f880ryvq8efh9522p8zvmrzlcrq",
+        "signDoc": {
+            "chain_id": "foochain",
+            "account_number": "7",
+            "sequence": "54"
+            "memo": "hello, world",
+            "msgs": [],
+            "fee": { "amount": [], "gas": "23" }
+        }
     }
-	}
 }
 
 // Result
 {
-  "id": 1,
-  "jsonrpc": "2.0",
-  "result":  {
-		"signature": "0274eb5ed4b696bf42070853a516bc66529c551f4f7885c6693a6fa1dc89534e50bd12958c89107ce665e4985d91fc4263e6baae1c0239855c6ca413265330e3",
-		"signDoc": {
-      "chain_id": "foochain",
-      "account_number": "7",
-      "sequence": "54"
-      "memo": "hello, world",
-      "msgs": [],
-      "fee": { "amount": [], "gas": "23" },
+    "id": 1,
+    "jsonrpc": "2.0",
+    "result":  {
+        "signature": {
+            "pub_key": {
+                "type": "tendermint/PubKeySecp256k1",
+                "value": "AgSEjOuOr991QlHCORRmdE5ahVKeyBrmtgoYepCpQGOW"
+            },
+            "signature": "AnTrXtS2lr9CBwhTpRa8ZlKcVR9PeIXGaTpvodyJU05QvRKVjIkQfOZl5JhdkfxCY+a6rhwCOYVcbKQTJlMw4w=="
+        },
+        "signDoc": {
+            "chain_id": "foochain",
+            "account_number": "7",
+            "sequence": "54"
+            "memo": "hello, world",
+            "msgs": [],
+            "fee": { "amount": [], "gas": "23" }
+        }
     }
-	}
 }
 ```


### PR DESCRIPTION
cosmos rpc seems to be built along cosmjs's offline signer/direct signer. However, there is a difference from the actual cosmjs interface.
Also, since cosmjs encodes most byte arrays to base64, we suggest replacing the existing hex-encoded part with base64.

### Changes
 - Base64 encode pubkey of `cosmos_getAccounts` response.
 - Add public key to signature of `signAmino/signDirect` response.
 - Fix some intent.