### PR TITLE
Use more semantic package name that can be imported directly in npm

### DIFF
--- a/docs/javascript/web3wallet/wallet-usage.md
+++ b/docs/javascript/web3wallet/wallet-usage.md
@@ -41,7 +41,7 @@ await web3wallet.core.pairing.pair({ uri });
 
 ## Session Rejection
 
-In the event you want to reject the session proposal, call the `rejectSession` method. The `getSDKError` function comes from the `@walletconnect-utils` [library](https://github.com/WalletConnect/walletconnect-monorepo/tree/v2.0/packages/utils).
+In the event you want to reject the session proposal, call the `rejectSession` method. The `getSDKError` function comes from the `@walletconnect/utils` [library](https://github.com/WalletConnect/walletconnect-monorepo/tree/v2.0/packages/utils).
 
 ```javascript
 web3wallet.on("session_proposal", async (proposal) => {
@@ -56,7 +56,7 @@ web3wallet.on("session_proposal", async (proposal) => {
 
 If either the dapp or the wallet decides to disconnect the session, the `session_delete` event will be emitted. The wallet should listen for this event in order to update the UI.
 
-To disconnect a session from the wallet, call the `disconnectSession` function and pass in the `topic` and `reason`. You can use the `getSDKError` function, which is available in the `@walletconnect-utils` [library](https://github.com/WalletConnect/walletconnect-monorepo/tree/v2.0/packages/utils).
+To disconnect a session from the wallet, call the `disconnectSession` function and pass in the `topic` and `reason`. You can use the `getSDKError` function, which is available in the `@walletconnect/utils` [library](https://github.com/WalletConnect/walletconnect-monorepo/tree/v2.0/packages/utils).
 
 ```javascript
 await web3wallet.disconnectSession({


### PR DESCRIPTION
The `@walletconnect/utils` package is referenced confusingly as `@walletconnect-utils`. This makes the package name more clear and easy for developers to import.