### PR TITLE
New RPC methods for Relay API

### DIFF
--- a/docs/specs/servers/relay/relay-server-rpc.md
+++ b/docs/specs/servers/relay/relay-server-rpc.md
@@ -242,6 +242,8 @@ Response will include a flag `hasMore`. If true, the consumer should fetch again
 
 Used when a client wants to fetch all undelivered messages matching multiple topics before subscribing.
 
+Response will include a flag `hasMore`. If true, the consumer should fetch again to get the rest of the messages. If false, then all messages have been delivered.
+
 ```jsonc
 // ReceivedMessage
 {


### PR DESCRIPTION
I've been meaning to create this PR for a long time as we have been talking for a whole year of potential optimizations for the client-server bandwidth and also addresses issues with rate limiting.

This PR introduces the following methods:

- [ ] irn_batchPublish
- [x] irn_batchSubscribe
- [x] irn_batchUnsubscribe
- [x] irn_fetchMessages
- [x] irn_batchFetchMessages

The most immediate optimization would be to use `irn_batchSubscribe` on client initialization rather looping 10-100s of `irn_subscribe` which is too intensive fro client to server bandwidth

The next optimization I propose is that we call `irn_batchFetchMessages` before we call the `irn_batchSubscribe` to also reduce the bandwidth from server to client.