### PR TITLE
feat: Improve Invite structures

### DIFF
--- a/docs/specs/clients/chat/client-api.md
+++ b/docs/specs/clients/chat/client-api.md
@@ -91,7 +91,7 @@ abstract class Client {
   // returns maps of invites indexed by id
   public abstract getReceivedInvites(params: {
     account: string;
-  }): Promise<Map<number, Invite>>
+  }): Promise<Map<number, ReceivedInvite>>
 
   // returns all pending invites matching an inviterAccount from SentInvite 
   // returns map of threads indexed by topic
@@ -113,7 +113,7 @@ abstract class Client {
   // ---------- Events ----------------------------------------------- //
 
   // subscribe to new chat invites received
-  public abstract on("chat_invite", ({ invite: Invite }) => {}): void;
+  public abstract on("chat_invite", ({ invite: ReceivedInvite }) => {}): void;
 
   // subscribe to new chat thread joined
   public abstract on("chat_joined",  ({ topic: string }) => {}): void;

--- a/docs/specs/clients/chat/client-api.md
+++ b/docs/specs/clients/chat/client-api.md
@@ -94,10 +94,10 @@ abstract class Client {
   }): Promise<Map<number, ReceivedInvite>>
 
   // returns all pending invites matching an inviterAccount from SentInvite 
-  // returns map of threads indexed by topic
+  // returns maps of invites indexed by id
   public abstract getSentInvites(params: {
     account: string;
-  }): Promise<Map<string, SentInvite>>;
+  }): Promise<Map<number, SentInvite>>;
 
   // returns all threads matching an selfAccount from Thread 
   // returns map of threads indexed by topic

--- a/docs/specs/clients/chat/data-structures.md
+++ b/docs/specs/clients/chat/data-structures.md
@@ -16,7 +16,7 @@ In this document we define data structures and definitions used in the chat api
 
 ## ReceivedInvite
 
-`ReceivedInvite` is a structure that is returned by SDK. Is extracted from Invite Proposals did-jwt claims. To get author account identity must be resolved from `iss` field. `inviteePublicKey` should be attach based on topic this invite was sent. A map of type `Map<number, ReceivedInvite>` is returned on `getReceivedInvites(params: {account: string})`. Topic is the key of the map.
+`ReceivedInvite` is a structure that is returned by SDK. Is extracted from Invite Proposals did-jwt claims. To get author account identity must be resolved from `iss` field. `inviteePublicKey` should be attach based on topic this invite was sent. A map of type `Map<number, ReceivedInvite>` is returned on `getReceivedInvites(params: {account: string})`. InviteId is the key of the map.
 
 
 ```jsonc

--- a/docs/specs/clients/chat/data-structures.md
+++ b/docs/specs/clients/chat/data-structures.md
@@ -26,7 +26,8 @@ In this document we define data structures and definitions used in the chat api
   "inviterAccount": string,
   "inviteeAccount": string,
   "inviterPublicKey": string,
-  "inviteePublicKey": string
+  "inviteePublicKey": string,
+  "status": 'pending' | 'rejected' | 'approved'
 }
 ```
 

--- a/docs/specs/clients/chat/data-structures.md
+++ b/docs/specs/clients/chat/data-structures.md
@@ -27,6 +27,7 @@ In this document we define data structures and definitions used in the chat api
   "inviteeAccount": string,
   "inviterPublicKey": string,
   "inviteePublicKey": string,
+  "timestamp": number, // taken from relay message receivedAt value
   "status": 'pending' | 'rejected' | 'approved'
 }
 ```
@@ -40,6 +41,7 @@ In this document we define data structures and definitions used in the chat api
   "message": string, // character limit is 200
   "inviterAccount": string,
   "inviteeAccount": string,
+  "timestamp": number, // taken from client current timestamp
   "status": 'pending' | 'rejected'
 }
 ```

--- a/docs/specs/clients/chat/data-structures.md
+++ b/docs/specs/clients/chat/data-structures.md
@@ -21,7 +21,7 @@ In this document we define data structures and definitions used in the chat api
 
 ```jsonc
 {
-  "id": number,
+  "id": number, // invite request RPC ID
   "message": string, // character limit is 200.
   "inviterAccount": string,
   "inviteeAccount": string,

--- a/docs/specs/clients/chat/data-structures.md
+++ b/docs/specs/clients/chat/data-structures.md
@@ -3,17 +3,43 @@
 In this document we define data structures and definitions used in the chat api
 
 ## Invite
+`Invite` is a structure used to call `invite(params: {invite: Invite;}): Promise<number>;`
 
-`Invite` is a structure that is returned by SDK. Is extracted from Invite Proposals did-jwt claims. To get author account identity must be resolved from `iss` field. A map of type `Map<number, Invite>` is returned on `getReceivedInvites(params: {account: string})`. Topic is the key of the map.
+```jsonc
+{
+  "message": string, // character limit is 200. Must be checked by SDK before sending
+  "inviterAccount": string,
+  "inviteeAccount": string,
+  "inviteePublicKey": string
+}
+```
+
+## ReceivedInvite
+
+`ReceivedInvite` is a structure that is returned by SDK. Is extracted from Invite Proposals did-jwt claims. To get author account identity must be resolved from `iss` field. `inviteePublicKey` should be attach based on topic this invite was sent. A map of type `Map<number, ReceivedInvite>` is returned on `getReceivedInvites(params: {account: string})`. Topic is the key of the map.
 
 
 ```jsonc
 {
   "id": number,
-  "message": string, // character limit is 200. Must be checked by SDK before sending
+  "message": string, // character limit is 200.
   "inviterAccount": string,
   "inviteeAccount": string,
   "inviterPublicKey": string,
+  "inviteePublicKey": string
+}
+```
+
+## SentInvite
+
+`SentInvite` structure keeps track of state of sent Invites. If Invite is approved by peer it should be removed from storage, if rejected should stay in storage. An array of `SentInvite` is returned on `getSentInvites(params: {account: string})`
+```jsonc
+{
+  "id": number,
+  "message": string, // character limit is 200
+  "inviterAccount": string,
+  "inviteeAccount": string,
+  "status": 'pending' | 'rejected'
 }
 ```
 
@@ -39,19 +65,6 @@ In this document we define data structures and definitions used in the chat api
   "authorAccount": string, // to distinguish who sent it
   "timestamp": Int64,
   "media": Media // optional
-}
-```
-
-## SentInvite
-
-`SentInvite` structure keeps track of state of sent Invites. If Invite is approved by peer it should be removed from storage, if rejected should stay in storage. An array of `SentInvite` is returned on `getSentInvites(params: {account: string})`
-```jsonc
-{
-  "id": number,
-  "message": string, // character limit is 200
-  "inviterAccount": string,
-  "inviteeAccount": string,
-  "status": 'pending' | 'rejected'
 }
 ```
 


### PR DESCRIPTION
The previous Invite structure was designed for the receiver of the invite not for the sender. Adds dedicated invite data structure for client `invite()` method. 