### PR TITLE
Add timestamp to received messages

### DIFF
--- a/docs/specs/clients/core/relay/relay-client-api.md
+++ b/docs/specs/clients/core/relay/relay-client-api.md
@@ -33,6 +33,9 @@ interface Relay {
 
     /*Closes a Web-Socket connection*/
     fun disconnect()
+    
+    /*Listening for new incoming messages*/
+    fun on("relay_message", (topic: string, message: string, timestamp: Int64) => {})
 }
 ```
 

--- a/docs/specs/clients/core/relay/relay-client-api.md
+++ b/docs/specs/clients/core/relay/relay-client-api.md
@@ -35,7 +35,7 @@ interface Relay {
     fun disconnect()
     
     /*Listening for new incoming messages*/
-    fun on("relay_message", (topic: string, message: string, timestamp: Int64) => {})
+    fun on("relay_message", (topic: string, message: string, publishedAt: Int64) => {})
 }
 ```
 

--- a/docs/specs/clients/core/relay/relay-client-api.md
+++ b/docs/specs/clients/core/relay/relay-client-api.md
@@ -35,7 +35,7 @@ interface Relay {
     fun disconnect()
     
     /*Listening for new incoming messages*/
-    fun on("relay_message", (topic: string, message: string, publishedAt: Int64) => {})
+    fun on("relay_message", (topic: string, message: string, publishedAt: Int64, receivedAt: Int64) => {})
 }
 ```
 

--- a/docs/specs/servers/relay/relay-server-rpc.md
+++ b/docs/specs/servers/relay/relay-server-rpc.md
@@ -101,7 +101,8 @@ Used when a server sends a subscription message to a client.
     "id" : string,
     "data" : {
       "topic" : string,
-      "message": string
+      "message": string,
+      "publishedAt": Int64
     }
   }
 }


### PR DESCRIPTION
Allow the Relay server to act as the source of truth for when messages are published