### PR TITLE
Add Web3Button to Install

### DIFF
--- a/docs/web3modal/react/installation.md
+++ b/docs/web3modal/react/installation.md
@@ -84,6 +84,16 @@ function App() {
 }
 ```
 
+## Add Connect Wallet Button
+
+```tsx
+import { Web3Button } from "@web3modal/react";
+
+export const YourApp = () => {
+  return <Web3Button />;
+};
+```
+
 ## Usage
 
 See [hooks](./hooks.md) and [components](components.md) docs for further instructions.


### PR DESCRIPTION
Add the Web3Button to the installation page for a smoother experience. It allows developers to do everything on one page.