### PR TITLE
Docs: WC V2 Migration information for @web3-onboard/walletconnect package

### DIFF
--- a/docs/advanced/migrating-from-v1.0.md
+++ b/docs/advanced/migrating-from-v1.0.md
@@ -77,6 +77,25 @@ If you are using `@walletconnect/react-native-dapp`, we currently don't have an 
 
 In the meantime, you can list all the wallet mobile links from our [Cloud Explorer API](https://docs.walletconnect.com/2.0/cloud/explorer) and integrate our `@walletconnect/ethereum-provider` package using the latest version available on NPM which you can find [here](https://npmjs.com/package/@walletconnect/ethereum-provider).
 
+#### For web3-onboard integrations
+
+If you are using the WalletConnect package with [Blocknative's web3-onboard](https://onboard.blocknative.com/docs/wallets/walletconnect#install)the migration is straight foward and the latest WC package is backwards compatible (until the WC v1 sunset).
+When ready to transition bump the `@web3-onboard/walletconnect` package version to >= `2.3.0` and adjust the initialization params to include: 
+```typescript 
+{
+  /**
+  * Defaults to version: 1 - this behavior will be deprecated after the WalletConnect v1 sunset
+  */
+  version: 2,
+  
+  /**
+  * Project ID associated with [WalletConnect account](https://cloud.walletconnect.com)
+  */
+  projectId: string
+}
+```
+*note: The `@web3-onboard/walletconnect` package will default to version 1 until the WC v1 sunset is complete*
+
 ### For Wallets
 
 Wallets must support v1.0 and v2.0 in parallel. Our WalletConnect URIs are versioned and you can route the URI that was either scanned from a QR Code or redirected from a Deep Link, following the schema described in the [EIP-1328](https://eips.ethereum.org/EIPS/eip-1328).

--- a/docs/advanced/migrating-from-v1.0.md
+++ b/docs/advanced/migrating-from-v1.0.md
@@ -79,7 +79,7 @@ In the meantime, you can list all the wallet mobile links from our [Cloud Explor
 
 #### For web3-onboard integrations
 
-If you are using the WalletConnect package with [Blocknative's web3-onboard](https://onboard.blocknative.com/docs/wallets/walletconnect#install)the migration is straight foward and the latest WC package is backwards compatible (until the WC v1 sunset).
+If you are using the WalletConnect package with [Blocknative's web3-onboard](https://onboard.blocknative.com/docs/wallets/walletconnect#install) the migration is straight forward. The latest WC package is backwards compatible (until the WC v1 sunset).
 When ready to transition bump the `@web3-onboard/walletconnect` package version to >= `2.3.0` and adjust the initialization params to include: 
 ```typescript 
 {


### PR DESCRIPTION
This PR adds migration info for WC V2 Migration information for the @web3-onboard/walletconnect package