### PR TITLE
add Push Message Record data structure

### DIFF
--- a/docs/specs/clients/push/data-structures.md
+++ b/docs/specs/clients/push/data-structures.md
@@ -24,4 +24,15 @@
   "url": string,
 }
 ```
+
+## Push Message Record
+
+```jsonc
+{
+  "id": string,
+  "topic": string,
+  "publishedAt": Int64,
+  "message": PushMessage
+}
+```
  

--- a/docs/specs/clients/push/wallet-client-api.md
+++ b/docs/specs/clients/push/wallet-client-api.md
@@ -17,7 +17,7 @@ abstract class WalletClient {
   public abstract getActiveSubscriptions(): Promise<Record<string, PushSubscription>>;
 
   // get all messages for a subscription
-  public abstract getMessageHistory(params: { topic: string }): Promise<Record<number, PushMessage>>
+  public abstract getMessageHistory(params: { topic: string }): Promise<Record<number, PushMessageRecord>>
 
   // delete active subscription
   public abstract deleteSubscription(params: { topic: string }): Promise<void>;
@@ -34,7 +34,7 @@ abstract class WalletClient {
   public abstract on("push_request", (id: number, account: string, metadata: Metadata) => {}): void;
   
   //  for wallet to listen on push messages
-  public abstract on("push_message", (message: PushMessage, metadata: Metadata) => {}): void;
+  public abstract on("push_message", (message: PushMessageRecord, metadata: Metadata) => {}): void;
 
   // for wallet to listen on push deletion
   public abstract on("push_delete", (topic: string) => {}): void;

--- a/docs/specs/clients/push/wallet-client-api.md
+++ b/docs/specs/clients/push/wallet-client-api.md
@@ -20,8 +20,11 @@ abstract class WalletClient {
   public abstract getMessageHistory(params: { topic: string }): Promise<Record<number, PushMessage>>
 
   // delete active subscription
-  public abstract delete(params: { topic: string }): Promise<void>;
-
+  public abstract deleteSubscription(params: { topic: string }): Promise<void>;
+  
+  // delete push message
+  public abstract deletePushMessage(params: { id: string }): Promise<void>;
+  
   // decrypt push subscription message
   public abstract decryptMessage(topic: string, encryptedMessage: string): Promise<PushMessage>;
 


### PR DESCRIPTION
- Add Push Message Record data structure
  `id` - for PM uniqueness, allows to delete message

- Add deletePushMessage() method to Wallet Push Client

If you guys prefer, we can also make it flat in PushMessage