### PR TITLE
chore: update the ethers version

### DIFF
--- a/docs/web3modal/html-js/installation.md
+++ b/docs/web3modal/html-js/installation.md
@@ -9,7 +9,7 @@ Head over to [WalletConnect Cloud](https://cloud.walletconnect.com/) to sign in 
 ## Add Packages
 
 ```bash npm2yarn
-npm install @web3modal/ethereum @web3modal/html @wagmi/core ethers
+npm install @web3modal/ethereum @web3modal/html @wagmi/core ethers@^5
 ```
 
 ## Import

--- a/docs/web3modal/react/installation.md
+++ b/docs/web3modal/react/installation.md
@@ -9,7 +9,7 @@ Head over to [WalletConnect Cloud](https://cloud.walletconnect.com/) to sign in 
 ## Add Packages
 
 ```bash npm2yarn
-npm install @web3modal/ethereum @web3modal/react wagmi ethers
+npm install @web3modal/ethereum @web3modal/react wagmi ethers@^5
 ```
 
 :::info


### PR DESCRIPTION
Context
- Ethers.js package updated to `v6`. wagmi relies on `v5`. 
- Similar to how wagmi docs have done it, have specified users to use `v5`

Wagmi [site](https://wagmi.sh/): `npm i wagmi ethers@^5`



