### PR TITLE
Add registerDeviceToken to Web3Wallet spec

### DIFF
--- a/docs/specs/meta-clients/web3wallet/sdk-api.md
+++ b/docs/specs/meta-clients/web3wallet/sdk-api.md
@@ -58,9 +58,9 @@ class Web3Wallet {
   // query all active sessions (SIGN)
   public abstract getActiveSessions(): Promise<Record<string, Session>>;
   
-  // format payload to message string
+  // format payload to message string (AUTH)
   public abstract formatMessage(payload: PayloadParams, iss: string): Promise<string>;
-
+  
   // query all pending session requests (SIGN)
   public abstract getPendingSessionProposals(): Promise<Record<number, SessionProposal>>;
   
@@ -69,7 +69,9 @@ class Web3Wallet {
   
   // query all pending auth requests (AUTH)
   public abstract getPendingAuthRequests(): Promise<Record<number, PendingRequest>>;
-
+  
+  // register device token for Echo server (BOTH)
+  public abstract registerDeviceToken(token: string): Promise<void>;
 
   // ---------- Events ----------------------------------------------- //
 


### PR DESCRIPTION
Make it easier for Wallet developers to register their device token for the Echo Server to receive Push Notifications for both Auth request and Sign sessions 

We also need to update docs for Web3Wallet SDKs in:
- [ ] Javascript
- [ ] Kotlin
- [ ] Swift

