### PR TITLE
Update broken link for the React Example.

### DIFF
--- a/docs/web3modal/standalone/installation.md
+++ b/docs/web3modal/standalone/installation.md
@@ -60,5 +60,5 @@ if (uri) {
 
 ## Examples
 
-- React [example](https://github.com/WalletConnect/web3modal/tree/V2/examples/react-standalone)
+- React [example](https://github.com/WalletConnect/web3modal/tree/V2/examples/nextjs-standalone)
 - HTML [example](https://github.com/WalletConnect/web3modal/tree/V2/examples/html-standalone)


### PR DESCRIPTION
Now pointing to the Next.js Example at 
https://github.com/WalletConnect/web3modal/tree/V2/examples/nextjs-standalone