### PR TITLE
Add wc_pairingExtend

### DIFF
--- a/docs/specs/clients/core/pairing/rpc-methods.md
+++ b/docs/specs/clients/core/pairing/rpc-methods.md
@@ -83,6 +83,36 @@ true
 | Tag     | 1003     |
 ```
 
+### wc_pairingExtend
+
+Used to update the lifetiem of a pairing.
+
+**Request**
+
+```jsonc
+// wc_pairingUpdateExpiry params
+{
+  "expiry": number
+}
+
+| IRN     |          |
+| ------- | -------- |
+| Prompt  | false    |
+| Tag     | 1004     |
+```
+
+**Response**
+
+```jsonc
+// Success result
+true
+
+| IRN     |          |
+| ------- | -------- |
+| Prompt  | false    |
+| Tag     | 1005     |
+```
+
 ### unsupported methods response
 
 Used to respond for requests that are not registered


### PR DESCRIPTION
Problem:
The Pairing API specifies a `updateExpiry` method, but there is no way to communicate an updated expiration time to the paired app/wallet.

I propose the following:

1. Changing `updateExpiry` in the pairing to match session's `extend`.
2. Adding a new RPC method, as listed here, that defines the way to update the expiration of the pairing for both connected parties.

It's totally possible that you guys decided you didn't want to have the ability to extend pairings. If that's the case, then we can close this PR, document that fact somewhere, and move on.