### PR TITLE
TTL Extension

### DIFF
--- a/docs/specs/clients/core/relay/relay-client-api.md
+++ b/docs/specs/clients/core/relay/relay-client-api.md
@@ -35,7 +35,7 @@ interface Relay {
     fun disconnect()
     
     /*Listening for new incoming messages*/
-    fun on("relay_message", (topic: string, message: string, publishedAt: Int64, receivedAt: Int64) => {})
+    fun on("relay_message", (topic: string, message: string, publishedAt: Int64, receivedAt: Int64, ttl: Int64) => {})
 }
 ```
 
@@ -57,6 +57,11 @@ A Relay message is globally available and it's always a utf8 string. Therefore t
 ```sh
 message_id = sha256(message)
 ```
+
+
+### Message expiration
+
+Relay server monitors message expiration by the ttl parameter but the client also has this ability. Client could track message expiration using combination of `publishedAt` and `ttl` params from `relay_message` subscription. 
 
 ## FAQ
 

--- a/docs/specs/clients/sign/client-api.md
+++ b/docs/specs/clients/sign/client-api.md
@@ -10,10 +10,12 @@ abstract class Client {
   }): Promise<void>;
 
   // for proposer to create a session 
+  // - note: supports ttl extension
   public abstract connect(params: {
     requiredNamespaces: Map<string, ProposalNamespace>;
     relays?: RelayProtocolOptions[];
     pairingTopic: string;
+    ttl: number; // optional
   }): Promise<Sequence>;
 
   // for responder to approve a session proposal
@@ -41,10 +43,12 @@ abstract class Client {
   }): Promise<void>;
 
   // for proposer to request JSON-RPC request
+  // - note: supports ttl extension
   public abstract request(params: {
     topic: string;
     request: RequestArguments;
     chainId: string;
+    ttl: number; // optional
   }): Promise<any>;
 
   // for responder to respond JSON-RPC request
@@ -60,7 +64,7 @@ abstract class Client {
     chainId: string;
   }): Promise<void>;
 
-    // for either to ping a peer in a session
+  // for either to ping a peer in a session
   public abstract ping(params: {
     topic: string;
   }): Promise<void>;

--- a/docs/specs/clients/sign/rpc-methods.md
+++ b/docs/specs/clients/sign/rpc-methods.md
@@ -31,6 +31,8 @@ Used to propose a session through topic A. Requires a success response with asso
 
 **Request**
 
+`wc_sessionPropose` supports [TTL Extension](./ttl-extension.md)
+
 ```jsonc
 // wc_sessionPropose params
 {
@@ -194,20 +196,7 @@ true
 
 Sends a CAIP-27 request to the peer client. The client should immediately reject the request and respond an error if the target session permissions doesn't include the requested method or chain ID.
 
-##### Expiry
-Param `Expiry` is an optional Unix timestamp. Sets the time until which the responder can respond to this request. If request is expired responder should respond with a specific error code.
-
-If this parameter is not specified, the request is considered indefinite.
-
-##### Expiry validation
-`Expiry` should be between `.now() + MIN_INTERVAL` and `.now() + MAX_INTERVAL` where:
-- `MIN_INTERVAL` is 300 (5 mins)
-- `MAX_INTERVAL` is 604800 (7 days)
-
-If expiry validation failed wallet should respond with `.sessionRequestExpired (code 8000)` error
-
-##### TTL extension
-When DApp is setting `expiry` params, client should insure that Relay Publish payload method `ttl` fit `expiry` value. Otherwise request `ttl` must be increased by the required value. Check [Relay Publish payload method](../../servers/relay/relay-server-rpc.md)
+`wc_sessionRequest` supports [TTL Extension](./ttl-extension.md)
 
 **Request**
 
@@ -217,7 +206,6 @@ When DApp is setting `expiry` params, client should insure that Relay Publish pa
   "request": {
     "method": string,
     "params": any,
-    "expiry": number // optional
   },
   "chainId": string
 }

--- a/docs/specs/clients/sign/ttl-extension.md
+++ b/docs/specs/clients/sign/ttl-extension.md
@@ -1,0 +1,20 @@
+# TTL Extension
+
+TTL extension allows clients to set custom expiration for specific RPC methods. 
+
+#### RPC Methods that support TTL Extension:
+- `wc_sessionRequest`
+- `wc_sessionPropose`
+
+#### TTL extension
+For supported TTL extension methods `ttl` params passing through Client API and setting into Relay Publish payload method. Check [Relay Publish payload method](../../servers/relay/relay-server-rpc.md)
+
+#### Expiry validation
+For supported TTL extension methods `ttl` params should be between `MIN_INTERVAL` and `MAX_INTERVAL` where:
+- `MIN_INTERVAL` is 300 (5 mins)
+- `MAX_INTERVAL` is 604800 (7 days)
+
+If ttl validation failed wallet should respond with `.sessionRequestExpired (code 8000)` error
+
+#### Expired requests filtering
+Records of methods that support TTL extension should be filtered by expiration before returning to clients. 


### PR DESCRIPTION
# Problem
1. Filtering expiration of Client specific methods like `getPendingRequests` and `getPendingProposals`: 
- `getPendingRequests` possible to filter by `expiry` param
- `getPendingProposals` not possible to filter by expiry

2. Currently we does not have consistence mechanism to track requests expiration. `wc_sessionRequest` has `isExpired` param, but setting it we still need to increase `ttl` for Relay Publish method. 

# Solution
Relay Publish `ttl` param should always be "source of truth" to calculate request expiration. 