### PR TITLE
Auto Namespaces

### DIFF
--- a/docs/specs/clients/sign/client-api.md
+++ b/docs/specs/clients/sign/client-api.md
@@ -71,6 +71,15 @@ abstract class Client {
     reason: Reason;
   }): Promise<void>;
 
+  // register an account for automated namespace creation (SIGN)
+  public abstract registerAccount(params: { chainId: string, accountAddress: string }): void;
+
+  // register an event emitter for the automated namespace creation (SIGN)
+  public abstract registerEventEmitter(params: { chainId: string, event: string }): void;
+
+  // register a method for the automated namespace creation (SIGN)
+  public abstract registerRequestHandler(params: { chainId: string, method: string }): void;
+
 
   // ---------- Events ----------------------------------------------- //
 

--- a/docs/specs/meta-clients/web3wallet/sdk-api.md
+++ b/docs/specs/meta-clients/web3wallet/sdk-api.md
@@ -73,6 +73,15 @@ class Web3Wallet {
   // register device token for Echo server (BOTH)
   public abstract registerDeviceToken(token: string): Promise<void>;
 
+  // register an account for automated namespace creation (SIGN)
+  public abstract registerAccount(params: { chainId: string, accountAddress: string }): void;
+
+  // register an event emitter for the automated namespace creation (SIGN)
+  public abstract registerEventEmitter(params: { chainId: string, event: string }): void;
+
+  // register a method for the automated namespace creation (SIGN)
+  public abstract registerRequestHandler(params: { chainId: string, method: string }): void;
+
   // ---------- Events ----------------------------------------------- //
 
   // subscribe to session proposal (SIGN)


### PR DESCRIPTION
I've added the functions I have implemented in the Flutter SDK to enable automated namespaces.

The registered methods, accounts, and events are stored as "available" with the following format:

- namespace1:chain1:address1
- namespace1:chain1:method1
- namespace1:chain1:event1

The goal of these is the following:
If wallets have registered accounts, methods, and events, then the Sign or Web3Wallet API can automatically create the Namespaces for the RequiredNamespaces based on the available accounts, methods, and events.
Then, once the automatic generation of the Namespaces is completed, the Sign or Web3Wallet API can automatically reject a proposal if the wallet does not satisfy the required namespaces.

I have implemented this in the [Flutter SDK](https://github.com/WalletConnect/WalletConnectFlutterV2/blob/83d4aa7f72858c56e27bff7f315df82499ef1c37/lib/apis/utils/namespace_utils.dart#L204)

My approach was to think of the available information as a large "bubble", and trim the available information to fit the RequiredNamespaces exactly, thus ensuring that the RequiredNamespaces "bubble" fit inside of the Available Namespaces.
You can see this image for a visual example of the idea.
![Screen Shot 2023-03-21 at 10 22 32 AM](https://user-images.githubusercontent.com/32227368/226673944-17aaeaf7-a6c7-4de2-9669-aebe5e7dbc10.png)