### PR TITLE
Storage Events

### DIFF
--- a/docs/specs/clients/core/storage/storage-api.md
+++ b/docs/specs/clients/core/storage/storage-api.md
@@ -7,5 +7,13 @@ export abstract class IKeyValueStorage {
   public abstract getItem<T = any>(key: string): Promise<T | undefined>;
   public abstract setItem<T = any>(key: string, value: T): Promise<void>;
   public abstract removeItem(key: string): Promise<void>;
+
+  // Emitted when a key is created, updated, or deleted
+  public abstract on<T = any>("create", (key: string, value: T) => {}): void;
+  public abstract on<T = any>("update", (key: string, value: T) => {}): void;
+  public abstract on<T = any>("delete", (key: string, value: T) => {}): void;
+
+  // Emitted when the store is persisted to disk
+  public abstract on("sync", () => {}): void;
 }
 ```


### PR DESCRIPTION
When building a UI for WalletConnect, we have to connect with multiple events in the Sign or Auth API to know when different internal values update.

This is not a straightforward approach.

I suggest adding the following events to the Storage API:
- onCreate, emitted when a new key is added
- onUpdate, emitted when a key that exists is updated in some way 
- onDelete, emitted when a key is removed
- onSync, emitted when data is persisted to disk

Some storage mechanisms in the Javascript repo already have events like these (JsonRpcHistory), and some have more (Expirer).

My goal is to make these events available for these storage endpoints: Pairings (Sign.Pairings), Sessions (Sign), Proposals (Sign), Cacao's (Auth, Completed Requests)

If the above storage endpoints exposing the 4 different events, keeping a UI in sync with internal changes becomes incredibly easy and straightforward.