### PR TITLE
docs: Removed addContact method

### DIFF
--- a/docs/specs/clients/chat/client-api.md
+++ b/docs/specs/clients/chat/client-api.md
@@ -83,12 +83,6 @@ abstract class Client {
     topic: string;
   }): Promise<void>;
 
-  // sets peer account with public key 
-  public abstract setContact(params: {
-    account: string;
-    publicKey: string;
-  }): Promise<void>
-
   // returns all invites matching an inviteeAccount from Invite 
   // returns maps of invites indexed by id
   public abstract getReceivedInvites(params: {


### PR DESCRIPTION
`addContact` method was no longer necessary since we changed `Invite` structure used as parameter in `client.invite()` method. `Invite` structure always contains `inviteePublicKey` which is `publicKeyX` from [specs](https://docs.walletconnect.com/2.0/specs/clients/chat/chat-invite)