### PR TITLE
feat(docs-link): Removed v1.0 mention from footer, other changes

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -119,12 +119,16 @@ const config = {
             title: 'Docs',
             items: [
               {
-                label: 'V1.0 Getting Started',
-                to: '/#getting-started'
-              },
-              {
                 label: 'v2.0 Getting Started',
                 to: '/2.0/#getting-started'
+              },
+              {
+                label: 'Web3Modal SDK',
+                to: '/2.0/web3modal/about'
+              },
+              {
+                label: 'Web3Wallet SDK',
+                to: '/2.0/web3wallet/about'
               }
             ]
           },


### PR DESCRIPTION
# What this PR does
Removed mention of v1.0 Getting Started from docs footer

Added links to [Web3Modal SDK](https://docs.walletconnect.com/2.0/web3modal/about) and [Web3Wallet SDK]((https://docs.walletconnect.com/2.0/web3wallet/about) for docs footer

# What it looks like

| Before | After |
| ------------- | ------------- |
| <img width="203" alt="image" src="https://user-images.githubusercontent.com/26746725/230015126-c7e3bb53-019a-4731-b445-ac48e7b2cece.png"> | <img width="223" alt="image" src="https://user-images.githubusercontent.com/26746725/230015615-e8be61a9-8161-4819-8804-1d01571b759e.png"> |

# Thoughts/Comments/Questions

Should we replace `Web3Modal SDK` with `Getting started for dApps` and `Web3Wallet SDK` with `Getting started for Wallets` or something along the lines of that?
