### PR TITLE
Update sync client specs to prevent redundancy

### DIFF
--- a/docs/specs/clients/sync/client-api.md
+++ b/docs/specs/clients/sync/client-api.md
@@ -16,11 +16,11 @@ abstract class Client {
   // create a store
   public abstract create(params: { account: string, store: string }): Promise<void>;
 
-  // set value 
-  public abstract set(params: { account: string, store: string, key: string, value: string }): Promise<void>;
+  // set value. Returns true if value changed, false otherwise.
+  public abstract set(params: { account: string, store: string, key: string, value: string }): Promise<boolean>;
 
-  // delete value 
-  public abstract delete(params: { account: string, store: string, key: string }): Promise<void>
+  // delete value. Returns true if value existed before delete, false otherwise. 
+  public abstract delete(params: { account: string, store: string, key: string }): Promise<boolean>
 
   // get stores
   public abstract getStores(params: { account: string }): Promise<StoreMap>;


### PR DESCRIPTION
# Changes
- `set` should now return true if the existing value is different from the provided new value.  False otherwise.
- `delete` should now return true if there is an existing value associated with the provided key pre the deletion. False otherwise.