### PR TITLE
Fix URL for Standalone Sign

### DIFF
--- a/docs/web3modal/about.md
+++ b/docs/web3modal/about.md
@@ -21,7 +21,7 @@ url: `/2.0/web3modal/html-js/installation`
 {
 name: "Standalone Sign",
 description: "Advanced Web3Modal usage without wagmi.",
-url: `/2.0/web3modal/standalone/installation`
+url: `/2.0/web3modal/advanced/standalone/sign/installation`
 },
 {
 name: "Standalone Auth",


### PR DESCRIPTION
This PR fixes the broken link for `Standalone Sign` on https://docs.walletconnect.com/2.0/web3modal/about