### PR TITLE
fix(push): ensures `lastModified` example aligns with definition

### DIFF
--- a/docs/specs/clients/push/push-notification-types.md
+++ b/docs/specs/clients/push/push-notification-types.md
@@ -31,7 +31,7 @@ https://example.com/.well-known/wc-push-config.json
 // wc-push-config.json
 {
   "version": 1,
-  "lastModified": 1680167470169,
+  "lastModified": 1681289416,
   "types": [
     {
       "name": "promotional",


### PR DESCRIPTION
* Spec references `in seconds` but concrete `lastModified` value shown is in milliseconds resolution