### PR TITLE
chore: remove duplicate npm install

### DIFF
--- a/docs/reactnative/web3wallet/Installation.md
+++ b/docs/reactnative/web3wallet/Installation.md
@@ -27,5 +27,5 @@ npm install @react-native-async-storage/async-storage react-native-get-random-va
 For those using Typescript, we recommend adding these dev dependencies:
 
 ```bash npm2yarn
-npm install npm install --save @walletconnect/jsonrpc-types
+npm install --save @walletconnect/jsonrpc-types
 ```


### PR DESCRIPTION
Had a duplicate npm install

Old version: 
<img width="937" alt="image" src="https://user-images.githubusercontent.com/45455218/231817329-bea0c66c-1a84-4570-a0c1-278ae067cf65.png">
