### PR TITLE
fix(specs): update push subscribe flow ordering

### DIFF
--- a/docs/specs/clients/push/push-subscribe.md
+++ b/docs/specs/clients/push/push-subscribe.md
@@ -25,7 +25,7 @@ Subscribe protocol will be established as follows:
 3. Wallet generates key pair Y
 4. Wallet derives symmetric key with keys X and Y
 5. Push topic is derived from sha256 hash of symmetric key
-6. Wallet subscribes to Push topic
+6. Wallet subscribes to subscription topic
 7. Wallet sends push subscribe request (type 1 envelope) on subscribe topic with subscriptionAuth
 8. Cast Server receives push subscribe request on subscribe topic
 9. Cast Server derives symmetric key and decrypts subscriptionAuth

--- a/docs/specs/clients/push/push-subscribe.md
+++ b/docs/specs/clients/push/push-subscribe.md
@@ -31,4 +31,4 @@ Subscribe protocol will be established as follows:
 9. Cast Server derives symmetric key and decrypts subscriptionAuth
 10. Cast Server triggers webhook to notify Dapp of new registered address
 11. Cast Server responds to push subscribe request
-12. Wallet receives push subscribe response on the push topic
+12. Wallet receives push subscribe response on the subscription topic

--- a/docs/specs/clients/push/push-subscribe.md
+++ b/docs/specs/clients/push/push-subscribe.md
@@ -24,7 +24,7 @@ Subscribe protocol will be established as follows:
 2. Wallet derives subscribe topic, which is the sha256 hash of public key X
 3. Wallet generates key pair Y
 4. Wallet derives symmetric key with keys X and Y
-5. Push topic is derived from sha256 hash of symmetric key
+5. Subscription topic is derived from sha256 hash of symmetric key
 6. Wallet subscribes to subscription topic
 7. Wallet sends push subscribe request (type 1 envelope) on subscribe topic with subscriptionAuth
 8. Cast Server receives push subscribe request on subscribe topic

--- a/docs/specs/clients/push/push-subscribe.md
+++ b/docs/specs/clients/push/push-subscribe.md
@@ -25,10 +25,10 @@ Subscribe protocol will be established as follows:
 3. Wallet generates key pair Y
 4. Wallet derives symmetric key with keys X and Y
 5. Push topic is derived from sha256 hash of symmetric key
-6. Wallet sends push subscribe request (type 1 envelope) on subscribe topic with subscriptionAuth
-7. Cast Server receives push subscribe request on subscribe topic
-8. Cast Server derives symmetric key and decrypts subscriptionAuth
-9. Cast Server triggers webhook to notify Dapp of new registered address
-10. Cast Server responds to push subscribe request
-11. Wallet receives push subscribe response
-12. Wallet subscribes to Push Topic which is sha256 of symmetric key
+6. Wallet subscribes to Push topic
+7. Wallet sends push subscribe request (type 1 envelope) on subscribe topic with subscriptionAuth
+8. Cast Server receives push subscribe request on subscribe topic
+9. Cast Server derives symmetric key and decrypts subscriptionAuth
+10. Cast Server triggers webhook to notify Dapp of new registered address
+11. Cast Server responds to push subscribe request
+12. Wallet receives push subscribe response on the push topic


### PR DESCRIPTION
## Context

- `Wallet subscribes to push topic` was right at the end, but the wallet already needs to be subscribed to the push topic to receive cast's response. 
- Moved it to `6.`