### PR TITLE
refactor push subscribe pattern

### DIFF
--- a/docs/specs/clients/push/push-authentication.md
+++ b/docs/specs/clients/push/push-authentication.md
@@ -25,4 +25,3 @@ This is achieved using [Identity Keys](../../servers/keys/identity-keys) and did
 `scp` - scope of notification types authorized by the user
 
 Expiry should be calculated from the addition of the issuance date and the push request TTL (86400 seconds)
- 

--- a/docs/specs/clients/push/push-subscribe.md
+++ b/docs/specs/clients/push/push-subscribe.md
@@ -21,14 +21,19 @@ The Push subscribe flow will require a dapp to host a static json file which wil
 Subscribe protocol will be established as follows:
 
 1. Wallet fetches public key X from the did:web document
-2. Wallet derives subscribe topic, which is the sha256 hash of public key X
+2. Subscribe topic is derived from the sha256 hash of public key X
 3. Wallet generates key pair Y
-4. Wallet derives symmetric key with keys X and Y
-5. Subscribe topic is derived from sha256 hash of symmetric key
-6. Wallet subscribes to subscribe topic
-7. Wallet sends push subscribe request (type 1 envelope) on subscribe topic with subscriptionAuth
+4. Wallet derives symmetric key S with keys X and Y
+5. Wallet sends push subscribe request (type 1 envelope) on subscribe topic with subscriptionAuth
+6. Response topic is derived from the sha256 hash of symmetric key S
+7. Wallet subscribes to response topic
 8. Cast Server receives push subscribe request on subscribe topic
 9. Cast Server derives symmetric key and decrypts subscriptionAuth
 10. Cast Server triggers webhook to notify Dapp of new registered address
-11. Cast Server responds to push subscribe request
-12. Wallet receives push subscribe response on the subscribe topic
+11. Cast Server generates key pair Z
+12. Cast Server derives symmetric key P with keys Y and Z
+13. Cast Server responds to push subscribe request on response topic
+14. Wallet receives push subscribe response on the response topic
+15. Wallet derives symmetric key P
+16. Push topic is derived from the sha256 hash of the symmetric key P
+17. Wallet subscribes to push topic for future push messages

--- a/docs/specs/clients/push/rpc-methods.md
+++ b/docs/specs/clients/push/rpc-methods.md
@@ -126,7 +126,7 @@ true
 
 ### wc_pushSubscribe
 
-Used to subscribe push subscription to a peer through topic S. Response is expected on the same topic.
+Used to subscribe push subscription to a peer through topic S. Response is expected on the response topic
 
 **Request**
 
@@ -147,7 +147,9 @@ Used to subscribe push subscription to a peer through topic S. Response is expec
 
 ```jsonc
 // Success result
-true
+{
+  "publicKey": string
+}
 
 | IRN     |          |
 | ------- | -------- |


### PR DESCRIPTION
This PR changes how wc_pushSubscribe is handled to be consistent with Chat Invites where it also uses 3 topics:
1. Subscribe
2. Response
3. Push