### PR TITLE
fix(specs): add descriptions for push subscription scope

### DIFF
--- a/docs/specs/clients/push/data-structures.md
+++ b/docs/specs/clients/push/data-structures.md
@@ -11,8 +11,8 @@
     "data": string
   },  
   "metadata": Metadata,
-  "scope": [string: bool],
-  "expiry": Int64,
+  "scope": Record<string, {description: string, enabled: boolean}>,
+  "expiry": number,
 }
 ```
 


### PR DESCRIPTION
- Store descriptions for known notification types/scopes in order to meaningfully render options (e.g. enable/disable) for them in UIs.
- Based on: https://docs.walletconnect.com/2.0/specs/clients/push/push-notification-types#configuration
- Also: aligns typings to be TS-compliant