### PR TITLE
fix(push): adds `push_update` event to WalletClient API

### DIFF
--- a/docs/specs/clients/push/wallet-client-api.md
+++ b/docs/specs/clients/push/wallet-client-api.md
@@ -51,6 +51,9 @@ abstract class WalletClient {
   
   //  for wallet to listen on push messages
   public abstract on("push_message", (message: PushMessageRecord, metadata: Metadata) => {}): void;
+  
+  // for wallet to listen for result of push subscription update
+  public abstract on("push_update", (result: PushSubscription | Error) => {}): void;
 
   // for wallet to listen on push deletion
   public abstract on("push_delete", (topic: string) => {}): void;


### PR DESCRIPTION
## Context

* The WalletClient requires a way to signal the result of `walletClient.update()` to the entity implementing the SDK (e.g. web3Inbox).
* We can  take a similar approach as with the `push_subscription` event, where `push_update` returns either:
	* the updated subscription
	* or an error