### PR TITLE
[Specs] Add TTL to irn_subscribe

### DIFF
--- a/docs/specs/servers/relay/relay-server-rpc.md
+++ b/docs/specs/servers/relay/relay-server-rpc.md
@@ -85,7 +85,7 @@ Used when a client subscribes a given topic.
   "method": "irn_subscribe",
   "params" : {
     "topic" : string,
-    "ttl": number
+    "ttl": number (optional / default = 604800 seconds)
   }
 }
 


### PR DESCRIPTION
This reduces the load on subscriptions by introducing an explicit expiry on `irn_subscribe` which is 7 days by default

For backwards-compatibility you cannot change the expiry on `irn_batchSubscribe` therefore it's assumed all topics are by default 7 days