### PR TITLE
feat: Adds a way to check if account was registered

### DIFF
--- a/docs/specs/clients/core/sync/client-api.md
+++ b/docs/specs/clients/core/sync/client-api.md
@@ -12,6 +12,9 @@ abstract class Client {
 
   // register an account to sync
   public abstract register(params: { account: string, signature: string }): Promise<void>;
+
+  // checks if account is already registered in sync
+  public abstract isRegistered(params: { account: string }): Promise<boolean>;
   
   // create a store
   public abstract create(params: { account: string, store: string }): Promise<void>;

--- a/docs/specs/clients/core/sync/client-api.md
+++ b/docs/specs/clients/core/sync/client-api.md
@@ -14,7 +14,7 @@ abstract class Client {
   public abstract register(params: { account: string, signature: string }): Promise<void>;
 
   // checks if account is already registered in sync
-  public abstract isRegistered(params: { account: string }): Promise<boolean>;
+  public abstract isRegistered(params: { account: string }): boolean;
   
   // create a store
   public abstract create(params: { account: string, store: string }): Promise<void>;


### PR DESCRIPTION
Small but powerful UX improvement. Currently, we always had to ask for a signature and then register. Now we could query the sdk if account did already register and then decide to ask for signature or move on