### PR TITLE
[Specs] Relay Webhook Refactor

### DIFF
--- a/docs/specs/servers/relay/relay-server-api.md
+++ b/docs/specs/servers/relay/relay-server-api.md
@@ -6,27 +6,8 @@ WebSocket supports JSON-RPC methods. For more details, please visit [Relay RPC d
 
 ## HTTP
 
-### Register Webhook
+### JSON-RPC
 
-Used to register a webhook that would return an incoming message to the webhook.
+Used to request JSON-RPC methods. For more details, please visit [Relay RPC docs](./relay-server-rpc.md).
 
-`POST /register-webhook`
-
-Body:
-
-```jsonc
-{
-    "clientId": string,
-    "webhook": string
-}
-```
-
-
-
-### Message Id
-
-A Relay message is globally available and it's always an utf8 string. Therefore the message id is derived as the sha256 hash.
-
-```sh
-message_id = sha256(message)
-```
+`POST /rpc`

--- a/docs/specs/servers/relay/relay-server-rpc.md
+++ b/docs/specs/servers/relay/relay-server-rpc.md
@@ -318,13 +318,15 @@ Watch events will be triggered for both incoming and outgoing messages but will 
 // RegisterAuth Payload
 {
    "act": string, // action (must be "irn_watchRegister")
-   "iss": string, // clientId
+   "typ": string, // either "subscriber" or "publisher"
+   "iss": string, // clientId (matches "typ")
    "aud": string, // relayUrl
    "sub": string, // serviceUrl
    "whu": string, // webhookUrl
    "iat": string, // issued at
    "exp": string, // expiry (max = 30 days)
    "tag": [1000, 1001, 1010, 1011] // array of tags
+   "sts": ["accepted", "queued", "delivered"] // array of status
 }
 
 // Request (service->relay)
@@ -361,10 +363,12 @@ Body:
   "act": string, // action (must be "irn_watchEvent")
   "iss": string, // relayId
   "aud": string, // serviceUrl
-  "sub": string, // clientId
-  "wid": string, // webhookId
+  "typ": string, // either "subscriber" or "publisher"
+  "sub": string, // clientId (matches "typ")
+  "whu": string, // webhook url
   "iat": string, // issued at
   "evt": {       // published message event
+    "status": string // either "accepted", "queued" or "delivered"
     "messageId": string,
     "topic": string,
     "message": string,

--- a/docs/specs/servers/relay/relay-server-rpc.md
+++ b/docs/specs/servers/relay/relay-server-rpc.md
@@ -308,16 +308,16 @@ Used to batch acknowledge receipt of messages from a subscribed client
 ```
 
 
-### Register Webhook
+### Register Watch (Webhook)
 
-Used to register a webhook to observe relay messages matching a given client.
+Used to register a webhook to watch relay messages matching a given client.
 
-Watch will be triggered for both incoming and outgoing messages but will not affect the delivery status of the messages.
+Watch events will be triggered for both incoming and outgoing messages but will not affect the delivery status of the messages in the mailbox.
 
 ```jsonc
 // RegisterAuth Payload
 {
-   "act": string, // action ("client_watch")
+   "act": string, // action (must be "irn_watchRegister")
    "iss": string, // clientId
    "aud": string, // relayUrl
    "sub": string, // serviceUrl
@@ -331,7 +331,7 @@ Watch will be triggered for both incoming and outgoing messages but will not aff
 {
   "id" : "1",
   "jsonrpc": "2.0",
-  "method": "irn_registerWebhook",
+  "method": "irn_watchRegister",
   "params" : {
     "registerAuth": string // jwt with RegisterAuth payload
   }
@@ -342,13 +342,15 @@ Watch will be triggered for both incoming and outgoing messages but will not aff
   "id" : "1",
   "jsonrpc": "2.0",
   "result": {
-    "webhookId": string, // sha256(act + iss + aud + sub + whu)
+    "webhookId": string, // sha256(iss + aud + sub + whu)
     "relayId": string // relay public key (did:key)
   }
 }
 ```
 
-Future publishedmessage events will be triggered on the corresponding webhook url ("whu") with the following body payload.
+#### Watch Events (Webhook)
+
+Future published message events will be triggered on the corresponding webhook url ("whu") with the following body payload.
 
 `POST <WEBHOOK_URL>`
 
@@ -384,14 +386,14 @@ Response:
 200
 ```
 
-### Unregister Webhook
+### Unregister Watch (Webhook)
 
-Used to unregister an active webhook corresponding to a webhookId 
+Used to unregister an active watch webhook corresponding to a webhookId.
 
 ```jsonc
 // UnregisterAuth Payload
 {
-   "act": string, // action ("client_unwatch")
+   "act": string, // action ("irn_watchUnregister")
    "iss": string, // clientId
    "aud": string, // serviceUrl
    "sub": string, // relayUrl
@@ -404,7 +406,7 @@ Used to unregister an active webhook corresponding to a webhookId
 {
   "id" : "1",
   "jsonrpc": "2.0",
-  "method": "irn_unregisterWebhook",
+  "method": "irn_watchUnregister",
   "params" : {
     "unregisterAuth": string // jwt with UnregisterAuth payload
   }

--- a/docs/specs/servers/relay/relay-server-rpc.md
+++ b/docs/specs/servers/relay/relay-server-rpc.md
@@ -186,7 +186,6 @@ Used when a server sends a subscription message to a client.
   "params" : {
     "id" : string,
     "data" : {
-      "messageId": string,
       "topic": string,
       "message": string,
       "publishedAt": number,
@@ -212,7 +211,6 @@ Response will include a flag `hasMore`. If true, the consumer should fetch again
 ```jsonc
 // ReceivedMessage
 {
-  "messageId": string,
   "topic": string,
   "message": string,
   "publishedAt": number,
@@ -368,8 +366,7 @@ Body:
   "whu": string, // webhook url
   "iat": string, // issued at
   "evt": {       // published message event
-    "status": string // either "accepted", "queued" or "delivered"
-    "messageId": string,
+    "status": string, // either "accepted", "queued" or "delivered"
     "topic": string,
     "message": string,
     "publishedAt": number,

--- a/docs/specs/servers/relay/relay-server-rpc.md
+++ b/docs/specs/servers/relay/relay-server-rpc.md
@@ -342,7 +342,6 @@ Watch events will be triggered for both incoming and outgoing messages but will 
   "id" : "1",
   "jsonrpc": "2.0",
   "result": {
-    "webhookId": string, // sha256(iss + aud + sub + whu)
     "relayId": string // relay public key (did:key)
   }
 }
@@ -395,10 +394,9 @@ Used to unregister an active watch webhook corresponding to a webhookId.
 {
    "act": string, // action ("irn_watchUnregister")
    "iss": string, // clientId
-   "aud": string, // serviceUrl
-   "sub": string, // relayUrl
+   "aud": string, // relayUrl
+   "sub": string, // serviceUrl
    "whu": string, // webhookUrl
-   "wid": string, // websocketId
    "iat": string, // issued at
 }
 

--- a/docs/specs/servers/relay/relay-server-rpc.md
+++ b/docs/specs/servers/relay/relay-server-rpc.md
@@ -16,7 +16,7 @@ The following definitions are shared concepts across all JSON-RPC methods for th
 
 
 ## Methods
-### Publish payload
+### Publish
 
 Used when a client publishes a message to a server.
 
@@ -42,7 +42,7 @@ Used when a client publishes a message to a server.
 }
 ```
 
-### Batch Publish payload
+### Batch Publish
 
 Used when a client publishes multiple messages to a server.
 
@@ -73,7 +73,7 @@ Used when a client publishes multiple messages to a server.
 }
 ```
 
-### Subscribe payload
+### Subscribe
 
 Used when a client subscribes a given topic.
 
@@ -96,7 +96,7 @@ Used when a client subscribes a given topic.
 }
 ```
 
-### Batch Subscribe payload
+### Batch Subscribe
 
 Used when a client subscribes multiple topics.
 
@@ -119,7 +119,7 @@ Used when a client subscribes multiple topics.
 }
 ```
 
-### Unsubscribe payload
+### Unsubscribe
 
 Used when a client unsubscribes a given topic.
 
@@ -143,7 +143,7 @@ Used when a client unsubscribes a given topic.
 }
 ```
 
-### Batch Unsubscribe payload
+### Batch Unsubscribe
 
 Used when a client unsubscribes a given topic.
 
@@ -173,7 +173,7 @@ Used when a client unsubscribes a given topic.
 ```
 
 
-### Subscription payload
+### Subscription
 
 Used when a server sends a subscription message to a client.
 
@@ -186,9 +186,10 @@ Used when a server sends a subscription message to a client.
   "params" : {
     "id" : string,
     "data" : {
-      "topic" : string,
+      "messageId": string,
+      "topic": string,
       "message": string,
-      "publishedAt: number,
+      "publishedAt": number,
       "tag": number
     }
   }
@@ -202,7 +203,7 @@ Used when a server sends a subscription message to a client.
 }
 ```
 
-### Fetch Messsages payload
+### Fetch Messsages
 
 Used when a client wants to fetch all undelivered messages matching a single topic before subscribing.
 
@@ -211,6 +212,7 @@ Response will include a flag `hasMore`. If true, the consumer should fetch again
 ```jsonc
 // ReceivedMessage
 {
+  "messageId": string,
   "topic": string,
   "message": string,
   "publishedAt": number,
@@ -240,7 +242,7 @@ Response will include a flag `hasMore`. If true, the consumer should fetch again
 
 
 
-### Batch Fetch Messsages payload
+### Batch Fetch
 
 Used when a client wants to fetch all undelivered messages matching multiple topics before subscribing.
 
@@ -276,18 +278,46 @@ Response will include a flag `hasMore`. If true, the consumer should fetch again
 }
 ```
 
+### Batch Receive
+
+Used to batch acknowledge receipt of messages from a subscribed client
+
+```jsonc
+// Receipt
+{
+  "topic": string,
+  "messageId": string
+}
+
+// Request (service->relay)
+{
+  "id" : "1",
+  "jsonrpc": "2.0",
+  "method": "irn_batchReceive",
+  "params" : {
+    "receipts": Receipt[]
+  }
+}
+
+// Response (relay->service)
+{
+  "id" : "1",
+  "jsonrpc": "2.0",
+  "result": true
+}
+```
+
+
 ### Register Webhook
 
 Used to register a webhook to observe relay messages matching a given client.
 
 Watch will be triggered for both incoming and outgoing messages but will not affect the delivery status of the messages.
 
-Subscribe will be triggered only for incoming messages and messages will be considered delivered when webhook event is successfuly received.
-
 ```jsonc
 // RegisterAuth Payload
 {
-   "act": string, // action ("client_watch" or "client_subscribe")
+   "act": string, // action ("client_watch")
    "iss": string, // clientId
    "aud": string, // serviceUrl
    "sub": string, // relayUrl
@@ -327,17 +357,18 @@ Body:
 ```jsonc
 // EventAuth Payload
 {
-  "act": string, // action (must be "irn_webhookEvent")
+  "act": string, // action (must be "irn_watchEvent")
   "iss": string, // relayId
   "aud": string, // serviceUrl
   "sub": string, // clientId
   "wid": string, // webhookId
   "iat": string, // issued at
   "evt": {       // published message event
-  "topic" : string,
-  "message": string,
-  "publishedAt": number,
-  "tag": number
+    "messageId": string,
+    "topic": string,
+    "message": string,
+    "publishedAt": number,
+    "tag": number
   }
 }
 
@@ -360,7 +391,7 @@ Used to unregister an active webhook corresponding to a webhookId
 ```jsonc
 // UnregisterAuth Payload
 {
-   "act": string, // action ("client_unwatch" or "client_unsubscribe")
+   "act": string, // action ("client_unwatch")
    "iss": string, // clientId
    "aud": string, // serviceUrl
    "sub": string, // relayUrl

--- a/docs/specs/servers/relay/relay-server-rpc.md
+++ b/docs/specs/servers/relay/relay-server-rpc.md
@@ -319,8 +319,8 @@ Watch will be triggered for both incoming and outgoing messages but will not aff
 {
    "act": string, // action ("client_watch")
    "iss": string, // clientId
-   "aud": string, // serviceUrl
-   "sub": string, // relayUrl
+   "aud": string, // relayUrl
+   "sub": string, // serviceUrl
    "whu": string, // webhookUrl
    "iat": string, // issued at
    "exp": string, // expiry (max = 30 days)

--- a/docs/specs/servers/relay/relay-webhooks.md
+++ b/docs/specs/servers/relay/relay-webhooks.md
@@ -1,0 +1,15 @@
+# Relay Webhooks
+
+Webhooks are used to delegate to third-party services with higher availability to watch both incoming and outgoing messages authorized by the client.
+
+Clients will be subscribed to different topics and they can register a watch webhook with a corresponding service url and webhook url to also receive messages matching these topics.
+
+Clients can register webhooks directly through JSON-RPC both with HTTP or WebSocket API and they can also unregister these webhooks independently if these services are unavailable.
+
+Watch webhooks will replicate published messages as webhook events but will not affect the delivery status of messages in the respective mailboxes.
+
+Relay will guarantee delivery of these watch webhooks up to the TTL of the published message with the maximum upper limit of 86 400 seconds (24 hours).
+
+Relay will use exponential backoff to retry delivering webhook events in case the target services are unavailable.
+
+Watch webhooks have a maximum expiry of 30 days and they must be re-registered to be extended.


### PR DESCRIPTION
In this PR we refactor the existing webhook mechanism to be authenticated by a client.

We also introduce two types of webhook actions: watch and subscribe

Finally we use RPC instead of REST as the interface for webhooks.

Project Brief: https://docs.google.com/document/d/16jjoIiOXhCrdBrXZsvYeGKtGbk_X_paucOb5WNuIT9k/edit#