### PR TITLE
fix(push-spec): corrects type for wc_pushPropose `scope` param

### DIFF
--- a/docs/specs/clients/push/rpc-methods.md
+++ b/docs/specs/clients/push/rpc-methods.md
@@ -171,7 +171,7 @@ Used to request push subscription to a peer through pairing topic. Response is e
   "publicKey": string,
   "metadata": Metadata,
   "account": string,
-  "scope": string
+  "scope": string[]
 }
 
 | IRN     |          |


### PR DESCRIPTION
* The `scope` parameter provided for `propose(...)` in the top level API is a string array `string[]`
* In the actual `wc_pushPropose` it only indicates `string` which creates ambiguity around how/if the `scope` parameter needs to be processed before sending in a JSON-RPC request.
* Correcting to `string[]` to align with the original top level type