### PR TITLE
Move FAQs to the bottom

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -91,7 +91,6 @@ module.exports = {
             'advanced/migration-from-v1.x/migration-faq',
           ]
         },
-        'advanced/faq',
         'advanced/glossary',
         {
           type: 'category',
@@ -253,7 +252,8 @@ module.exports = {
               ]
             }
           ]
-        }
+        },
+        'advanced/faq',
       ]
     }
   ],


### PR DESCRIPTION
Move FAQs to the bottom to avoid two FAQs:
<img width="313" alt="image" src="https://github.com/WalletConnect/walletconnect-docs/assets/44731696/d61dcb0d-8db5-4209-bda7-0c28ecfed4f3">


In favor of:
<img width="307" alt="image" src="https://github.com/WalletConnect/walletconnect-docs/assets/44731696/b35d4abc-a199-4060-90a0-9d23a7ca5acd">
