### PR TITLE
Add account filtering for active subs

### DIFF
--- a/docs/specs/clients/push/wallet-client-api.md
+++ b/docs/specs/clients/push/wallet-client-api.md
@@ -28,7 +28,7 @@ abstract class WalletClient {
 
   // query all active subscriptions
   public abstract getActiveSubscriptions(params: {
-    account: string
+    account?: string
   }): Promise<Record<string, PushSubscription>>;
 
   // get all messages for a subscription

--- a/docs/specs/clients/push/wallet-client-api.md
+++ b/docs/specs/clients/push/wallet-client-api.md
@@ -27,7 +27,9 @@ abstract class WalletClient {
   }): Promise<boolean>;
 
   // query all active subscriptions
-  public abstract getActiveSubscriptions(): Promise<Record<string, PushSubscription>>;
+  public abstract getActiveSubscriptions(params: {
+    account: string
+  }): Promise<Record<string, PushSubscription>>;
 
   // get all messages for a subscription
   public abstract getMessageHistory(params: { topic: string }): Promise<Record<number, PushMessageRecord>>


### PR DESCRIPTION
# Changes
Add params to `getActiveSubscriptions` to filter by account as right now, regardless of what wallet account queried the subscriptions, they'll all get the same result, which should not be the case

## Example
This can be seen in Web3inbox when logging into account A, subscribing, logging out, then logging into account B and querying active subs. 