### PR TITLE
docs(push): updates JS push docs for push-client@0.10.0

### DIFF
--- a/docs/web/push/dapp-usage.md
+++ b/docs/web/push/dapp-usage.md
@@ -6,13 +6,24 @@
 Its public API and associated documentation may still see breaking changes.
 :::
 
-## Prerequisites
+## Enabling Push Notifications for your Dapp
 
+In order to enable push notifications for your dapp, you will need to:
+
+1. Sign up to [WalletConnect Cloud](https://cloud.walletconnect.com) and create a project. This will also provide you with a Project ID, which is required for all WalletConnect SDKs.
+2. On your project's page, navigate to the `Explorer` tab and fill out the required fields, including the homepage URL of your dapp.
+3. Click `Save` to validate and save your project's details.
+4. Next, navigate to the `Settings` tab.
+5. Under `Push SDK`, download both the `did.json` the `wc-push-config.json` files that have been preconfigured based on your dapp's homepage URL.
+6. Host both files in your dapp's `/.well-known` directory, so that they are accessible at `/.well-known/did.json` and `/.well-known/wc-push-config.json` respectively.
+
+## Usage
+
+:::info
 The **`PushDappClient` requires an existing pairing** in order to send a push subscription request to the wallet.
 This means that the `PushDappClient` should be used alongside the [Sign SDK](../sign/installation.md) or the
 [Auth SDK](../auth/installation.md), via the [Shared Core](../guides/shared-core.md) setup.
-
-## Usage
+:::
 
 **1. Initialize your WalletConnect Core, using [your Project ID](../../cloud/relay.md), and pass it to the SDK clients**
 

--- a/docs/web/push/wallet-usage.md
+++ b/docs/web/push/wallet-usage.md
@@ -6,12 +6,12 @@
 Its public API and associated documentation may still see breaking changes.
 :::
 
-## Prerequisites
+## Usage
 
+:::info
 The **`PushWalletClient` requires an existing pairing** in order to receive a push subscription request from a dapp.
 This means that the `PushWalletClient` should be used alongside the [Web3Wallet SDK](../web3wallet/installation.md), via the [Shared Core](../guides/shared-core.md) setup.
-
-## Usage
+:::
 
 **1. Initialize your WalletConnect Core, using [your Project ID](../../cloud/relay.md), and pass it to the SDK clients**
 


### PR DESCRIPTION
## Context

- Updates dapp and wallet usage docs to reflect https://github.com/WalletConnect/push-client-js/releases/tag/0.10.0
- Adds `Enabling Push Notifications for your Dapp` section for dapps, outlining how to get the required `did.json` and `wc-push-config.json` files set up via Cloud.