### PR TITLE
Fix a few typos in the React Sign API docs

### DIFF
--- a/docs/web/walletConnectModal/_partials/sign-api/connectReference.mdx
+++ b/docs/web/walletConnectModal/_partials/sign-api/connectReference.mdx
@@ -1,4 +1,4 @@
-[CAIP](https://github.com/ChainAgnostic/CAIPs) complaint namespace. [Learn more about namespaces](../../../../specs/clients/sign/namespaces)
+[CAIP](https://github.com/ChainAgnostic/CAIPs) compliant namespace. [Learn more about namespaces](../../../../specs/clients/sign/namespaces)
 
 ```ts
 interface Namespace {

--- a/docs/web/walletConnectModal/sign/react/hooks.mdx
+++ b/docs/web/walletConnectModal/sign/react/hooks.mdx
@@ -113,7 +113,7 @@ request()
 ### Reference
 
 ```ts
-useDisconnect: (options: RequestOptions) => ({ request, data, error, loading })
+useRequest: (options: RequestOptions) => ({ request, data, error, loading })
 ```
 
 ```ts


### PR DESCRIPTION
### Summary
- Fixed typo "complaint" > "compliant"
- Fixed example under `useRequest` to use that method. Previously had `useDisconnect` in example.