### PR TITLE
Update rpc-methods.md

### DIFF
--- a/docs/specs/clients/push/rpc-methods.md
+++ b/docs/specs/clients/push/rpc-methods.md
@@ -42,7 +42,7 @@ Used to publish a notification message to a peer through push topic. Response is
 
 | IRN     |          |
 | ------- | -------- |
-| TTL     | 86400    |
+| TTL     | 2592000  |
 | Tag     | 4002     |
 
 ```


### PR DESCRIPTION
if user opens wallet 24h after the push message was published, the message will expire in the mailbox and will never be delivered to the user(with relay). that's causes missing push messages like experience.
Solution: extend wc_pushMessage ttl to 30days