### PR TITLE
fix: About Web3modal HTML getting started link

### DIFF
--- a/docs/web/about-web3modal.mdx
+++ b/docs/web/about-web3modal.mdx
@@ -24,7 +24,7 @@ Check out [web3modal.com](https://web3modal.com) for a live demo and in-depth fe
     {
       name: 'HTML',
       description: 'Use with any framework or vanilla HTML',
-      url: '/2.0/web/web3modal/react/wagmi/installation'
+      url: '/2.0/web/web3modal/html/wagmi/installation'
     }
   ]}
 />


### PR DESCRIPTION
Previously, both getting started links pointed to React.
Now the second one is corrected to point to HTML getting started.