### PR TITLE
Change the key `showQrCode` to `showQrModal`.

### DIFF
--- a/docs/advanced/migration-from-v1.x/dapps/dapps.md
+++ b/docs/advanced/migration-from-v1.x/dapps/dapps.md
@@ -59,7 +59,7 @@ import { EthereumProvider } from '@walletconnect/ethereum-provider'
 const provider = await EthereumProvider.init({
   projectId: 'WALLETCONNECT_PROJECT_ID', // required
   chains: [1], // required
-  showQrCode: true // requires @walletconnect/modal
+  showQrModal: true // requires @walletconnect/modal
 })
 ```
 


### PR DESCRIPTION
I think this is a mistake, there is no `showQrCode` key in the `EthereumProviderOptions`.

```
export interface EthereumProviderOptions {
    projectId: string;
    chains: number[];
    optionalChains?: number[];
    methods?: string[];
    optionalMethods?: string[];
    events?: string[];
    optionalEvents?: string[];
    rpcMap?: EthereumRpcMap;
    metadata?: Metadata;
    showQrModal: boolean;
    qrModalOptions?: QrModalOptions;
    disableProviderPing?: boolean;
    relayUrl?: string;
    storageOptions?: KeyValueStorageOptions;
}
```

Before:

```js
import { EthereumProvider } from '@walletconnect/ethereum-provider'

const provider = await EthereumProvider.init({
  projectId: 'WALLETCONNECT_PROJECT_ID', // required
  chains: [1], // required
  showQrCode: true // requires @walletconnect/modal
})
```


After:
```js
import { EthereumProvider } from '@walletconnect/ethereum-provider'

const provider = await EthereumProvider.init({
  projectId: 'WALLETCONNECT_PROJECT_ID', // required
  chains: [1], // required
  showQrModal: true // requires @walletconnect/modal
})
```