### PR TITLE
fix: adds callout to disambiguate Explorer vs protocol chain support

### DIFF
--- a/docs/advanced/multichain/overview.md
+++ b/docs/advanced/multichain/overview.md
@@ -4,6 +4,15 @@ The WalletConnect protocol is multi-chain by design. By using the [CAIP-25 stand
 
 ## Register Chain with the Explorer
 
+:::info
+**Registering a chain with the Explorer does not impact or improve the ability for wallets and dapps to support your chain.** It is simply a way for users to discover wallets and dapps that support your chain by:
+
+- Browsing the [Chains List](./chain-list.md)
+- Filtering results programmatically via the [Explorer API](../../cloud/explorer.md)
+
+It is up to wallets and dapps to provide concrete support for your chain. **A wallet or dapp can also support your chain without it first being listed in the Explorer.**
+:::
+
 If you don't see your chain listed in this [list](./chain-list.md), then you will need to create an issue in GitHub to to get the process started.
 You can do so by clicking [here](https://github.com/WalletConnect/walletconnect-monorepo/issues/new?assignees=&labels=type%3A+new+chain+request&template=new_chain_to_explorer.md&title=). Once your chain is added to this list, wallets & dapps will be able to indicate support for your chain via WalletConnect's [Cloud](https://cloud.walletconnect.com).
 

--- a/docs/advanced/multichain/overview.md
+++ b/docs/advanced/multichain/overview.md
@@ -10,7 +10,7 @@ The WalletConnect protocol is multi-chain by design. By using the [CAIP-25 stand
 - Browsing the [Chains List](./chain-list.md)
 - Filtering results programmatically via the [Explorer API](../../cloud/explorer.md)
 
-It is up to wallets and dapps to provide concrete support for your chain. **A wallet or dapp can also support your chain without it first being listed in the Explorer.**
+**It is still up to wallets and dapps to provide concrete support for your chain once it is listed as part of the Explorer.**
 :::
 
 If you don't see your chain listed in this [list](./chain-list.md), then you will need to create an issue in GitHub to to get the process started.


### PR DESCRIPTION
## Context

- We seem to getting a number of Explorer chain requests misunderstanding the actual effects of a chain being added to the Explorer as: `Explorer listing == wallet/dapp support`
- Our documentation seems to leave this open to interpretation at the moment
- This info admonition attempts to clarify that there is no direct cause-effect relationship between the two