### PR TITLE
cast: move to bearer auth

### DIFF
--- a/docs/specs/servers/cast/cast-server-api.md
+++ b/docs/specs/servers/cast/cast-server-api.md
@@ -24,7 +24,7 @@ Used to register a webhook that would return when accounts are subscribed or uns
 `POST /register-webhook`
 
 ### Authentication
-Cast server expects an `Authorization` header in the form `Authorization: <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
+Cast server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
 
 Body:
 
@@ -62,7 +62,7 @@ Used to retrieve the list of registered webhooks
 `GET /webhooks`
 
 ### Authentication
-Cast server expects an `Authorization` header in the form `Authorization: <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key` 
+Cast server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
 
 Response:
 
@@ -95,7 +95,7 @@ Used to update the registered webhook
 `PUT /webhooks/<webhook_id>`
 
 ### Authentication
-Cast server expects an `Authorization` header in the form `Authorization: <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key` 
+Cast server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
 
 Body:
 
@@ -115,7 +115,7 @@ Used to delete the registered webhook
 `DELETE /webhooks/<webhook_id>`
 
 ### Authentication
-Cast server expects an `Authorization` header in the form `Authorization: <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key` 
+Cast server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
 
 ## Notify
 
@@ -124,7 +124,7 @@ Used to notify a message to a set of accounts
 `POST /notify`
 
 ### Authentication
-Cast server expects an `Authorization` header in the form `Authorization: <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key` 
+Cast server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
 
 Body:
 
@@ -169,7 +169,7 @@ Used to generate a subscribe topic for a dapp to receive push subscriptions, ret
 `GET /subscribe-topic`
 
 ### Authentication
-Cast server expects an `Authorization` header in the form `Authorization: <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key` 
+Cast server expects an `Authorization` header in the form `Authorization: Bearer <project_secret>` using the project secret associated with a project id. The secret used should be the one that was generated automatically when configuring notify - with the name`cast_subscribe_topic_public_key`  
 
 Response:
 


### PR DESCRIPTION
Moving to Bearer auth to match HTTP specs.
