### PR TITLE
Add special namespaces specs

### DIFF
--- a/docs/specs/clients/sign/client-api.md
+++ b/docs/specs/clients/sign/client-api.md
@@ -7,6 +7,7 @@ abstract class Client {
   // initializes the client with persisted storage and a network connection
   public abstract init(params: {
     metadata?: AppMetadata;
+    specialNamespaces?: SpecialNamespaces[] // optional
   }): Promise<void>;
 
   // for proposer to create a session 

--- a/docs/specs/clients/sign/data-structures.md
+++ b/docs/specs/clients/sign/data-structures.md
@@ -52,6 +52,10 @@ Session is a topic encrypted by a symmetric key derived using a key agreement es
       "events": [string]
     }
   },
+  "specialNamespaces": {
+      "methods": [string],
+      "events": [string]
+  }
 }
 ```
 

--- a/docs/specs/clients/sign/data-structures.md
+++ b/docs/specs/clients/sign/data-structures.md
@@ -146,6 +146,10 @@ Settlement is sent by the responder after approval and it's broadcasted right af
       "events": [string]
     }
   },
+  "specialNamespaces": {
+    "methods": [string],
+    "events": [string]
+  }
   "sessionProperties": {
     "property": string
   },

--- a/docs/specs/clients/sign/namespaces.md
+++ b/docs/specs/clients/sign/namespaces.md
@@ -60,7 +60,7 @@ If they are valid, then the wallet if free to decide whether to approve the prop
 
 If the wallet (or the user) does NOT approve the session, then it is rejected. Otherwise, the wallet responds with a slightly different namespace schema: Session Namespace. Instead of having a list of `chains`, it has list of `accounts` compatible with the given methods and events. If the wallet approves a session proposal, it needs to approve all methods and events of all Proposal Namespaces. If needed, the Wallet can add permissions for more methods and events than the ones requested, but never less.
 
-Wallet can also define special namespaces that do not require a target chain and are preffixed with "wallet_". Special namespace are always defined by a wallet in the init function of SignSDK and can be used to send method such as: wallet_switchEthereumChain. A key for special namespaces in session namespaces is defined as "wallet".
+Wallet can also define special namespaces that do not require a target chain and are preffixed with "wallet_". Special namespace are always defined by a wallet in the init function of SignSDK and can be used to send method such as: wallet_switchEthereumChain.
 
 ### Example Session Namespace
 
@@ -88,11 +88,11 @@ Wallet can also define special namespaces that do not require a target chain and
       ],
       "methods": ["polkadot_signTransaction", "polkadot_signMessage"],
       "events": []
-    },
-    "wallet": {
-      "methods": ["wallet_getPermissions", "wallet_switchEthereumChain", "wallet_creds_store"],
-      "events": []
     }
+  },
+  "specialNamespaces": {
+    "methods": ["wallet_getPermissions", "wallet_switchEthereumChain", "wallet_creds_store"],
+    "events": []
   }
 }
 ```

--- a/docs/specs/clients/sign/namespaces.md
+++ b/docs/specs/clients/sign/namespaces.md
@@ -60,6 +60,8 @@ If they are valid, then the wallet if free to decide whether to approve the prop
 
 If the wallet (or the user) does NOT approve the session, then it is rejected. Otherwise, the wallet responds with a slightly different namespace schema: Session Namespace. Instead of having a list of `chains`, it has list of `accounts` compatible with the given methods and events. If the wallet approves a session proposal, it needs to approve all methods and events of all Proposal Namespaces. If needed, the Wallet can add permissions for more methods and events than the ones requested, but never less.
 
+Wallet can also define special namespaces that do not require a target chain and are preffixed with "wallet_". Special namespace are always defined by a wallet in the init function of SignSDK and can be used to send method such as: wallet_switchEthereumChain. A key for special namespaces in session namespaces is defined as "wallet".
+
 ### Example Session Namespace
 
 ```json
@@ -85,6 +87,10 @@ If the wallet (or the user) does NOT approve the session, then it is rejected. O
         "polkadot:91b171bb158e2d3848fa23a9f1c25182:A1MbgM4mdFBH4LiTPZWmtVZ3zBGUJApN24FoSK32ZACPGP6"
       ],
       "methods": ["polkadot_signTransaction", "polkadot_signMessage"],
+      "events": []
+    },
+    "wallet": {
+      "methods": ["wallet_getPermissions", "wallet_switchEthereumChain", "wallet_creds_store"],
       "events": []
     }
   }

--- a/docs/specs/clients/sign/rpc-methods.md
+++ b/docs/specs/clients/sign/rpc-methods.md
@@ -101,6 +101,10 @@ Used to settle a session over topic B.
       "events": [string]
     }
   },
+  "specialNamespaces": { // optional
+    "methods": [string],
+    "events": [string]
+  }
   "expiry": Int64, // seconds
 }
 

--- a/docs/specs/meta-clients/web3wallet/sdk-api.md
+++ b/docs/specs/meta-clients/web3wallet/sdk-api.md
@@ -3,7 +3,10 @@
 ```typescript
 class Web3Wallet {
   // initializes the client (BOTH)
-  public abstract init(params: { core: CoreClient }): Promise<void>;
+  public abstract init(params: { 
+    core: CoreClient,
+    specialNamespaces?: SpecialNamespaces[] // optional
+    }): Promise<void>;
   
   // establish pairing from URI (BOTH)
   public abstract pair(params: { uri: string }): Promise<void>;


### PR DESCRIPTION
Some of the key items:
- Special Namespaces are defined by a wallet in the init function of Sign or Web3Wallet SDK
- Special Namespaces are sent as a part of the wc_sessionSettle method
- Special Namespaces are prefixed with "wallet_"
- Special Namespaces are a part of the Session object

Validation:
- Wallet validates whether the received special method/event is included in the Special Namespaces
- Dapp validates whether the request/event is included in the Special Namespaces before sending