### PR TITLE
Update React Native documentation to include missing @react-native-community/netinfo dependency

### DIFF
--- a/docs/web3wallet/about.mdx
+++ b/docs/web3wallet/about.mdx
@@ -136,7 +136,7 @@ npm install @walletconnect/web3wallet @walletconnect/react-native-compat
 Additionally add these extra packages to help with async storage, polyfills and the instance of ethers.
 
 ```bash npm2yarn
-npm install @react-native-async-storage/async-storage react-native-get-random-values fast-text-encoding @ethersproject/shims ethers@5.7.2 @json-rpc-tools/utils
+npm install @react-native-async-storage/async-storage @react-native-community/netinfo react-native-get-random-values fast-text-encoding @ethersproject/shims ethers@5.7.2 @json-rpc-tools/utils
 ```
 
 For those using Typescript, we recommend adding these dev dependencies:


### PR DESCRIPTION
## Overview
While going through the `react-native` documentation, I noticed that the `@react-native-community/netinfo` dependency was missing. This PR aims to address this oversight and ensure that users have all the necessary information to set up their projects.

## Changes
- Added `@react-native-community/netinfo` to the list of dependencies in the documentation.


https://github.com/WalletConnect/walletconnect-monorepo/blob/v2.0/packages/react-native-compat/package.json#L30
