### PR TITLE
add link to CASA namespaces docs from chain-list page

### DIFF
--- a/docs/advanced/multichain/chain-list.md
+++ b/docs/advanced/multichain/chain-list.md
@@ -4,6 +4,8 @@ import List from '../../components/List.js'
 
 This is an active list of all the known and registered chains that have been configured to work within the WalletConnect Ecosystem. If your chain is missing and you would like to have it added, you can do so by creating a [GitHub issue](https://github.com/WalletConnect/walletconnect-monorepo/issues/new?assignees=&labels=type%3A+new+chain+request&template=new_chain_to_explorer.md&title=). 
 
-Note that to register a chain, you must know both its native representation (the chainID used with that kind of blockchain) *and* its Chain Agnostic Standards Alliance representation, which can be found reading the relevant CAIP-2 profiles on the [CASA Namespaces Project Docs](https://namespaces.chainagnostic.org/).
+:::info Note 
+To register a chain, you must know both its native representation (the chainID used with that kind of blockchain) *and* its Chain Agnostic Standards Alliance representation, which can be found reading the relevant CAIP-2 profiles on the [CASA Namespaces Project Docs](https://namespaces.chainagnostic.org/).
+:::
 
 <List />

--- a/docs/advanced/multichain/chain-list.md
+++ b/docs/advanced/multichain/chain-list.md
@@ -2,6 +2,8 @@ import List from '../../components/List.js'
 
 # Chain List
 
-This is an active list of all the chains that are configured to work within the WalletConnect Ecosystem. If your chain is missing and you would like to have it added, you can do so by creating a [GitHub issue](https://github.com/WalletConnect/walletconnect-monorepo/issues/new?assignees=&labels=type%3A+new+chain+request&template=new_chain_to_explorer.md&title=).
+This is an active list of all the known and registered chains that have been configured to work within the WalletConnect Ecosystem. If your chain is missing and you would like to have it added, you can do so by creating a [GitHub issue](https://github.com/WalletConnect/walletconnect-monorepo/issues/new?assignees=&labels=type%3A+new+chain+request&template=new_chain_to_explorer.md&title=). 
+
+Note that to register a chain, you must know both its native representation (the chainID used with that kind of blockchain) *and* its Chain Agnostic Standards Alliance representation, which can be found reading the relevant CAIP-2 profiles on the [CASA Namespaces Project Docs](https://namespaces.chainagnostic.org/).
 
 <List />


### PR DESCRIPTION
as discussed on Slack with @glitch-txs  and [here](https://github.com/orgs/WalletConnect/discussions/3527).  i'm not particularly/picky if people want to change the wording (i.e. just go ahead and change it and merge it without waiting for my approval!). I just thought people should know that *in theory* the entire universe of valid CAIP-2s can be used with WC (they just need to be registered).