### PR TITLE
Changed rn dapp example links

### DIFF
--- a/docs/advanced/walletconnectmodal/about.mdx
+++ b/docs/advanced/walletconnectmodal/about.mdx
@@ -156,7 +156,7 @@ To enable WalletConnectModal to detect wallets installed on the device, you need
 1. Open your `Info.plist` file.
 2. Locate the `<key>LSApplicationQueriesSchemes</key>` section.
 3. Add the desired wallet schemes as string entries within the `<array>`. These schemes represent the wallets you want to detect.
-4. Refer to our [Info.plist example file](https://github.com/WalletConnect/react-native-examples/blob/main/dapps/v2Explorer/ios/Web3Modal/Info.plist) for a detailed illustration.
+4. Refer to our [Info.plist example file](https://github.com/WalletConnect/react-native-examples/blob/main/dapps/ModalUProvider/ios/ModalUProvider/Info.plist) for a detailed illustration.
 
 Example:
 ```xml
@@ -176,7 +176,7 @@ Example:
 1. Open your `AndroidManifest.xml` file.
 2. Locate the `<queries>` section.
 3. Add the desired wallet package names as `<package>` entries within the `<queries>`. These package names correspond to the wallets you want to detect.
-4. Refer to our [AndroidManifest.xml example file](https://github.com/WalletConnect/react-native-examples/blob/main/dapps/v2Explorer/android/app/src/main/AndroidManifest.xml) for detailed guidance.
+4. Refer to our [AndroidManifest.xml example file](https://github.com/WalletConnect/react-native-examples/blob/main/dapps/ModalUProvider/android/app/src/main/AndroidManifest.xml) for detailed guidance.
 
 Example:
 ```xml

--- a/docs/advanced/walletconnectmodal/resources.mdx
+++ b/docs/advanced/walletconnectmodal/resources.mdx
@@ -34,7 +34,10 @@ To check more in details go and visit our [WalletConnect Modal Kotlin implementa
 </PlatformTabItem>
 <PlatformTabItem value="react-native">
 
-To check more in details go and visit our [WalletConnect Modal React Native implementation app](https://github.com/WalletConnect/modal-react-native/tree/main/example)
+* Check our implementation of [Modal + Viem](https://github.com/WalletConnect/react-native-examples/tree/main/dapps/ModalViem)
+* Check our implementation of [Modal + Ethers](https://github.com/WalletConnect/react-native-examples/tree/main/dapps/ModalEthers)
+* Check our implementation of [Modal + Universal Provider](https://github.com/WalletConnect/react-native-examples/tree/main/dapps/ModalUProvider)
+* To check more in details go and visit our [WalletConnect Modal React Native implementation app](https://github.com/WalletConnect/modal-react-native/tree/main/example)
 
 </PlatformTabItem>
 <PlatformTabItem value="flutter">


### PR DESCRIPTION
### Summary
Added links for Modal + Viem/Ethers/UProvider examples

Related with: https://github.com/WalletConnect/react-native-examples/pull/99