### PR TITLE
operationHash to hash

### DIFF
--- a/docs/advanced/rpc-reference/tezos-rpc.md
+++ b/docs/advanced/rpc-reference/tezos-rpc.md
@@ -68,7 +68,7 @@ Note: All [RPC Operations](https://github.com/ecadlabs/taquito/blob/4dc6c391047b
 ### Returns
 
     1. `Object` - Signing parameters:
-    	1.1. `operationHash` : `STRING` - hash of the operation
+    	1.1. `hash` : `STRING` - hash of the operation
 
 ### Example
 
@@ -95,7 +95,7 @@ Note: All [RPC Operations](https://github.com/ecadlabs/taquito/blob/4dc6c391047b
     "id": 1,
     "jsonrpc": "2.0",
     "result":  {
-        "operationHash": "op..."
+        "hash": "op..."
     }
 }
 ```


### PR DESCRIPTION
objkt.com is currently one of the main dApps using walletconnect in the Tezos echosystem. The dApp accepts 'hash' and not 'operationHash'. If the dapp is using the 'truthy' version of the spec, this PR fixes the docs.