### PR TITLE
w3m: added extra step for installed wallets

### DIFF
--- a/docs/web3modal/react-native/about.mdx
+++ b/docs/web3modal/react-native/about.mdx
@@ -198,6 +198,13 @@ Learn more about the Web3Modal hooks [here](./hooks.mdx)
 ## Enable Wallet Detection
 To enable WalletConnectModal to detect wallets installed on the device, you need to make specific changes to the native code of your project.
 
+First, add our core dependency to your package.json file so React Native links it's native code to your project
+
+```bash npm2yarn
+npm install @web3modal/core-react-native
+```
+
+
 <Tabs groupId="platform">
   <TabItem value="rn-cli" label="React Native CLI">
 
@@ -222,6 +229,7 @@ To enable WalletConnectModal to detect wallets installed on the device, you need
   ```
 
   #### For Android:
+
 
   1. Open your `AndroidManifest.xml` file.
   2. Locate the `<queries>` section.


### PR DESCRIPTION
### Summary
Added extra step to detect installed wallets in w3m-rn

Solves:
React Native doesn't link native code unless is explicitly added in the package.json, so in order to detect installed wallets we need to add core package to the project. 

[Related issue](https://github.com/react-native-community/cli/issues/870)