### PR TITLE
fix: type of chains in OpenOptions

### DIFF
--- a/docs/advanced/walletconnectmodal/usage.mdx
+++ b/docs/advanced/walletconnectmodal/usage.mdx
@@ -348,7 +348,7 @@ interface OpenOptions {
   uri: string
   // CAIP-2 compliant chain ids to override initial chains defined when creating the modal
   // Learn about CAIP-10: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md
-  chains?: string
+  chains?: string[]
 }
 ```
 


### PR DESCRIPTION
Fixes docs type to match [`OpenOptions`](https://github.com/WalletConnect/modal/blob/95571fb4e96bd2a5c36214e657dc66aae0f1c8b4/packages/modal-core/src/controllers/ModalCtrl.ts#L10)