### PR TITLE
Remove WagmiConfig mentions in Next.js example using ethers

### DIFF
--- a/docs/web3modal/nextjs/ethers/about/implementation.mdx
+++ b/docs/web3modal/nextjs/ethers/about/implementation.mdx
@@ -42,7 +42,7 @@ createWeb3Modal({
 })
 
 export function Web3ModalProvider({ children }) {
-  return <div>{children}</div>;
+  return children;
 }
 ```
 

--- a/docs/web3modal/nextjs/ethers/about/implementation.mdx
+++ b/docs/web3modal/nextjs/ethers/about/implementation.mdx
@@ -41,8 +41,8 @@ createWeb3Modal({
   projectId
 })
 
-export function Web3Modal({ children }) {
-  return <WagmiConfig config={wagmiConfig}>{children}</WagmiConfig>;
+export function Web3ModalProvider({ children }) {
+  return <div>{children}</div>;
 }
 ```
 
@@ -62,7 +62,7 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <body>
-        <Web3Modal>{children}</Web3Modal>
+        <Web3ModalProvider>{children}</Web3ModalProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
In the previous version of the current code example, there was a `<WagmiConfig />` component and `wagmiConfig` as a prop passed to the component. However, neither the `wagmiConfig` nor the `WagmiConfig` provided was mentioned above. I attempted to remove them, and it worked successfully for me.

As a relatively new user of Next.js, I am using version "next": "14.0.1" and incorporating the app router. To streamline my code, I've consolidated all my providers into `app/providers.tsx`. Additionally, I've placed the implementation code for `createWeb3Modal(...)` right before the actual `<CombineProvider />` component begins.

In the current patch, I've modified `Web3Connect.tsx` to have a simple div wrapper, allowing the injection of vanilla JavaScript code without the inclusion of actual providers.

With this fix, you may consider adjusting the description to provide more context on the file placement.