### PR TITLE
fix: removed .env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,9 @@ Source can be viewed in [`docs`](./docs/) directory.
 
 ## Running Locally
 
-1. `echo "MARKPROMPT_KEY=..." > .env`
-   - You can get this key from the Engineering team or leave it empty to bypass the AI powered Ask feature.`
 1. `yarn install`
-1. `yarn start`
-1. Open `http://localhost:3000/`
+2. `yarn start`
+3. Open `http://localhost:3000/`
 
 ## Adding a New Page
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,10 +1,13 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 
-require('dotenv').config()
-
 const darkCodeTheme = require('prism-react-renderer/themes/dracula')
 const lightCodeTheme = require('prism-react-renderer/themes/github')
+
+const projectKey =
+  process.env.NODE_ENV === 'production'
+    ? 'Uuv6kG5tEsMxJaTbj66ljUoei91qg1La'
+    : 'sk_test_uH7GmxPmqXDxpn4x6EXi4V5Hg4PsQFFh'
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -65,7 +68,7 @@ const config = {
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     {
       markprompt: {
-        projectKey: process.env.MARKPROMPT_KEY,
+        projectKey,
         trigger: {
           floating: false,
           placeholder: 'Search or Ask AI'

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^2.4.3",
-    "dotenv": "^16.3.1",
     "prettier": "2.8.8",
     "typedoc-plugin-markdown": "3.15.3",
     "typescript": "4.9.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3964,11 +3964,6 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
-dotenv@^16.3.1:
-  version "16.3.1"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
-  integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==
-
 downshift@^8.1.0:
   version "8.2.3"
   resolved "https://registry.yarnpkg.com/downshift/-/downshift-8.2.3.tgz#27106a5d9f408a6f6f9350ca465801d07e52db87"


### PR DESCRIPTION
Removed env file required for markprompt before