### PR TITLE
fix: Web3Inbox SDK fixes

### DIFF
--- a/docs/api/notify/usage.mdx
+++ b/docs/api/notify/usage.mdx
@@ -111,7 +111,7 @@ const onSign = (message: string) => ethersWallet.signMessage(message)
 await notifyClient.register({
   account,
   onSign,
-  domain: 'app.mydomain.com', // pass the domain (i.e. the hostname) where your dapp is hosted.
+  domain: 'app.example.com', // pass the domain (i.e. the hostname) where your dapp is hosted.
   isLimited: true // The user will be prompted to authorize this dapp to send and receive messages on their behalf for this domain using their WalletConnect identity.
 })
 ```
@@ -125,7 +125,7 @@ const onSign = (message: string) => ethersWallet.signMessage(message)
 await notifyClient.register({
   account,
   onSign,
-  domain: 'com.mydomain.app.rn', // pass your app's bundle identifier.
+  domain: 'com.example.app.rn', // pass your app's bundle identifier.
   isLimited: false // The user will be prompted to authorize this wallet to send and receive messages on their behalf for ALL domains using their WalletConnect identity.
 })
 
@@ -840,7 +840,7 @@ const onSign = (message: string) => ethersWallet.signMessage(message)
 await notifyClient.register({
   account,
   onSign,
-  domain: 'app.mydomain.com', // pass the domain (i.e. the hostname) where your dapp is hosted.
+  domain: 'app.example.com', // pass the domain (i.e. the hostname) where your dapp is hosted.
   isLimited: true // The user will be prompted to authorize this dapp to send and receive messages on their behalf for this domain using their WalletConnect identity.
 })
 ```
@@ -854,7 +854,7 @@ const onSign = (message: string) => ethersWallet.signMessage(message)
 await notifyClient.register({
   account,
   onSign,
-  domain: 'com.mydomain.app.rn', // pass your app's bundle identifier.
+  domain: 'com.example.app.rn', // pass your app's bundle identifier.
   isLimited: false // The user will be prompted to authorize this wallet to send and receive messages on their behalf for ALL domains using their WalletConnect identity.
 })
 ```

--- a/docs/components/PlatformTabs.js
+++ b/docs/components/PlatformTabs.js
@@ -31,10 +31,6 @@ const PLATFORM_MAP = [
     label: 'HTML'
   },
   {
-    value: 'javascript',
-    label: 'JavaScript'
-  },
-  {
     value: 'react-native',
     label: 'React Native'
   },

--- a/docs/components/PlatformTabs.js
+++ b/docs/components/PlatformTabs.js
@@ -31,6 +31,10 @@ const PLATFORM_MAP = [
     label: 'HTML'
   },
   {
+    value: 'javascript',
+    label: 'JavaScript'
+  },
+  {
     value: 'react-native',
     label: 'React Native'
   },
@@ -65,10 +69,6 @@ const PLATFORM_MAP = [
   {
     value: 'web3js',
     label: 'Web3.js'
-  },
-  {
-    value: 'js',
-    label: 'JavaScript'
   }
 ]
 

--- a/docs/web3inbox/domain-setup.mdx
+++ b/docs/web3inbox/domain-setup.mdx
@@ -7,6 +7,8 @@ Follow these steps to obtain a Notify API Secret and enable your domain to send 
 
 During development it is optional to use your production domain for testing. Instead, you can use a staging domain, or even a entirerly separate domain e.g. Vercel test site. However, because notification subscriptions are tied to the domain, once you move to production you will need to deploy these files to your production domain.
 
+Note that the use of `localhost` domain here is not supported. The `did.json` file below must be hosted on a publically accessible domain in order for Cloud and other endpoints (e.g. a user's wallet) to verify its legitimacy.
+
 For a quick start to experiment with, you can try the [gm-hackers template](https://github.com/WalletConnect/gm-hackers) and following the steps in the README.
 
 <CloudBanner />

--- a/docs/web3inbox/frontend-integration/api.mdx
+++ b/docs/web3inbox/frontend-integration/api.mdx
@@ -9,30 +9,33 @@ import CloudBanner from '../../components/CloudBanner'
 
 ## Init
 
+To setup the client you need to configure it with your `projectId` which you can obtain from [WalletConnect Cloud](https://cloud.walletconnect.com).
+
+Furthremore you may need to configure the `domain` and `isLimited` parameters:
+
+- `domain` defaults to `window.location.host` and must be set to the domain setup in [Domain Setup](../domain-setup). For example `app.example.com`. Do not add the scheme (`https://`).
+- `isLimited` determines if your app has access to all of the user's subscriptions, or only the ones that the app is hosted on. By setting it to `false`, it enables setting `domain` to a value other than `window.location.host`. Setting `isLimited: false` can be useful during development to allow your localhost-deployed app to access the subscriptions for the domain you setup. Note that most apps do not need to set this in production environments, as they only need access to their own subscriptions. When enabled, the user has to sign a SIWE message granting your app more permissions, and this requires additional consideration from the user.
+
 <PlatformTabs
 	groupId="w3iw"
-	activeOptions={["react", "javascript"]}
+	activeOptions={["react", "js"]}
 >
-
-Init the client
 
 <PlatformTabItem value="react">
 
 ```ts
-// You can optionally pass a domain to override the behavior of using window.location
-const clientIsReady = useInitWeb3inboxClient({ projectId, domain, isLimited })
-const client = useWeb3InboxClient()
+const isReady = useInitWeb3inboxClient({ projectId, domain, isLimited })
 ```
 
 #### References
 
 - **projectId:** Your WalletConnect project ID
-- **domain *(Optional)*:** your dapp domain 
-- **isLimited:** Set to `false` to request access to all of the user's notification subscriptions for all apps. Most do not need to set this, as they only need access to their own subscriptions.
+- **domain _(Optional)_:** Your app's domain. Defaults to `window.location.host`.
+- **isLimited _(Optional)_:** Set to `false` to request access to all of the user's notification subscriptions for all apps, instead of only `domain`. Defaults to `true`.
 
 </PlatformTabItem>
 
-<PlatformTabItem value="javascript">
+<PlatformTabItem value="js">
 
 ```ts
 const client = await Web3InboxClient.init({ projectId, domain, isLimited })
@@ -41,8 +44,8 @@ const client = await Web3InboxClient.init({ projectId, domain, isLimited })
 #### References
 
 - **projectId:** Your WalletConnect project ID
-- **domain *(Optional)*:** your dapp domain 
-- **isLimited:** Set to `false` to request access to all of the user's notification subscriptions for all apps. Most do not need to set this, as they only need access to their own subscriptions.
+- **domain _(Optional)_:** Your app's domain. Defaults to `window.location.host`.
+- **isLimited _(Optional)_:** Set to `false` to request access to all of the user's notification subscriptions for all apps, instead of only `domain`. Defaults to `true`.
 
 </PlatformTabItem>
 </PlatformTabs>
@@ -53,27 +56,32 @@ Register, set and fetch account.
 
 :::note
 Register needs to be called after every page load or Web3InboxClient `init`, even if the
-account is registered. This is to enable state synchronization.
+account is already registered. This is to enable state synchronization.
 :::
 
 <PlatformTabs
 	groupId="w3iw"
-	activeOptions={["react", "javascript"]}
+	activeOptions={["react", "js"]}
 >
-
 
 <PlatformTabItem value="react">
 
 ```ts
 const { account, setAccount, register } = useW3iAccount()
 
-register(onSign)
+setAccount('eip155:1:0x9AfEaC202C837df470b5A145e0EfD6a574B21029')
+
+useEffect(async () => {
+  console.log({ account }) // eip155:1:0x9AfEaC202C837df470b5A145e0EfD6a574B21029
+  await register(onSign)
+}, [account])
 ```
 
 #### References
 
 - **account:** CAIP-10 account currently active in Web3Inbox
 - **setAccount:** Change actively managed account in Web3Inbox
+- **register:** Async function used to register an account
 - **onSign:** Async function used to sign a message (for registering) of type:
 
 <!-- prettier-ignore-start -->
@@ -89,22 +97,21 @@ Some suggested ways to implement the `onSign` callback are via:
 
 <!-- prettier-ignore-end -->
 
-- **register:** Async function used to register an account
-
 </PlatformTabItem>
 
-<PlatformTabItem value="javascript">
+<PlatformTabItem value="js">
 
 ```ts
-const account = client.getAccount()
-client.setAccount('eip155:1:...')
+await client.setAccount('eip155:1:0x9AfEaC202C837df470b5A145e0EfD6a574B21029')
 
-let reactiveAccountState = ''
-client.watchAccount(acc => (reactiveAccountState = acc))
+const account = client.getAccount() // eip155:1:0x9AfEaC202C837df470b5A145e0EfD6a574B21029
+client.watchAccount(account => {
+  console.log({ account }) // eip155:1:0x9AfEaC202C837df470b5A145e0EfD6a574B21029
 
-client.register({
-  account,
-  onSign,
+  client.register({
+    account,
+    onSign
+  })
 })
 ```
 
@@ -112,11 +119,13 @@ client.register({
 
 - **account:** CAIP-10 account currently active in Web3Inbox
 - **setAccount:** Change actively managed account in Web3Inbox
+- **register:** Async function used to register an account
 - **onSign:** Async function used to sign a message (for registering) of type:
 
 <!-- prettier-ignore-start -->
+
 ```ts
-(message: string) => Promise
+;(message: string) => Promise<string>
 ```
 
 Some suggested ways to implement the `onSign` callback are via:
@@ -134,7 +143,7 @@ Subscribe, Unsubscribe, Get Subscription, Check if Subscribed.
 
 <PlatformTabs
 	groupId="w3iw"
-	activeOptions={["react", "javascript"]}
+	activeOptions={["react", "js"]}
 >
 
 <PlatformTabItem value="react">
@@ -171,8 +180,8 @@ const subscriptions = useSubscriptions(account)
 
 #### References
 
-- **account *(Optional)*:** CAIP-10 account 
-- **domain *(Optional)*:** dapp domain 
+- **account _(Optional)_:** CAIP-10 account
+- **domain _(Optional)_:** dapp domain
 - **subscribe:** Function to subscribe to current dApp `() => void`
 - **unsubscribe:** Function to unsubscribe to current dApp `() => void`
 - **isSubscribed:** Reactive state, checking if subscribed to dApp `Boolean`
@@ -190,48 +199,47 @@ const subscriptions = useSubscriptions(account)
 }
 ```
 
-- **subscriptions:** Reactive state, returning array of current subscriptions 
+- **subscriptions:** Reactive state, returning array of current subscriptions
 
 </PlatformTabItem>
-<PlatformTabItem value="javascript">
+<PlatformTabItem value="js">
 
 ```ts
 // check if current account is subscribed to current dapp
-const isSubscribed = client.getIsSubscribedTo()
+const isSubscribed = client.isSubscribedToDapp()
 
 // check if specific account is subscribed to current dapp
-const isSubscribed = client.getIsSubscribedTo(account)
+const isSubscribed = client.isSubscribedToDapp(account)
 
 // check if specific account is subscribed to specific dapp
-const isSubscribed = client.getIsSubscribedTo(account, domain)
+const isSubscribed = client.isSubscribedToDapp(account, domain)
 
-let isSubscribedReactive = false
 // watch if current account is subscribed to current dapp
-client.watchIsSubscribed(isSubbed => (isSubscribedReactive = isSubbed))
+client.watchIsSubscribed(isSubbed => console.log({ isSubbed }))
 
 // watch if specific account is subscribed to current dapp
-client.watchIsSubscribed(isSubbed => (isSubscribedReactive = isSubbed), account)
+client.watchIsSubscribed(isSubbed => console.log({ isSubbed }), account)
 
 // watch if specific account is subscribed to specific dapp
-client.watchIsSubscribed(isSubbed => (isSubscribedReactive = isSubbed), account, domain)
+client.watchIsSubscribed(isSubbed => console.log({ isSubbed }), account, domain)
 
 // subscribe to current dapp with current account
-client.subscribeToDapp()
+await client.subscribeToDapp()
 
 // subscribe to current dapp with specific account
-client.subscribeToDapp(account)
+await client.subscribeToDapp(account)
 
 // subscribe to specific dapp with specific account
-client.subscribeToDapp(account, domain)
+await client.subscribeToDapp(account, domain)
 
 // unsubscribe from current dapp with current account
-client.unsubscribeFromDapp()
+await client.unsubscribeFromDapp()
 
 // unsubscribe from current dapp with specific account
-client.unsubscribeFromDapp(account)
+await client.unsubscribeFromDapp(account)
 
 // subscribe from specific dapp with specific account
-client.unsubscribeToDapp(account, domain)
+await client.unsubscribeToDapp(account, domain)
 
 // get current account's subscription to current dapp
 const subscription = client.getSubscription()
@@ -242,17 +250,32 @@ const subscription = client.getSubscription(account)
 // get specific account's subscription to specific dapp
 const subscription = client.getSubscription(account, domain)
 
-// get current account's subscriptions.
-const subscriptions = client.getSubscriptions();
+// watch current account's subscription to current dapp
+client.watchSubscription(subscription => console.log({ subscription }))
 
-// get specific account's subscriptions.
-const subscriptions = client.getSubscriptions(account);
+// watch specific account's subscription to current dapp
+client.watchSubscription(subscription => console.log({ subscription }), account)
+
+// watch specific account's subscription to specific dapp
+client.watchSubscription(subscription => console.log({ subscription }), account, domain)
+
+// get current account's subscriptions
+const subscriptions = client.getSubscriptions()
+
+// get specific account's subscriptions
+const subscriptions = client.getSubscriptions(account)
+
+// watch current account's subscriptions
+client.watchSubscriptions(subscriptions => console.log({ subscriptions }))
+
+// watch specific account's subscriptions
+client.watchSubscriptions(subscriptions => console.log({ subscriptions }), account)
 ```
 
 #### References
 
-- **account *(Optional)*:** CAIP-10 account 
-- **domain *(Optional)*:** dapp domain 
+- **account _(Optional)_:** CAIP-10 account
+- **domain _(Optional)_:** dapp domain
 - **subscription:** _Non-Reactive_ state, returning current subscription information, of type:
 
 ```ts
@@ -271,7 +294,7 @@ const subscriptions = client.getSubscriptions(account);
 
 </PlatformTabItem>
 </PlatformTabs>
-	
+
 
 ## Managing Messages
 
@@ -279,13 +302,12 @@ Get and delete messages
 
 <PlatformTabs
 	groupId="w3iw"
-	activeOptions={["react", "javascript"]}
+	activeOptions={["react", "js"]}
 >
 
 <PlatformTabItem value="react">
 
 ```ts
-
 // watch messages of current account's subscription to current dapp
 const { messages, deleteMessage } = useMessages()
 
@@ -300,8 +322,8 @@ deleteMessage(messages[0].id)
 
 #### References
 
-- **account *(Optional)*:** CAIP 10 account
-- **domain *(Optional)*:** Domain of dapp
+- **account _(Optional)_:** CAIP 10 account
+- **domain _(Optional)_:** Domain of dapp
 - **messages:** Array of messages, of type
 
 ```ts
@@ -314,7 +336,7 @@ deleteMessage(messages[0].id)
 ```
 
 </PlatformTabItem>
-<PlatformTabItem value="javascript">
+<PlatformTabItem value="js">
 
 ```ts
 const nonReactiveMessageState = client.getMessageHistory(account)
@@ -332,8 +354,8 @@ client.watchMessages(m => (reactiveMessageState = m), account, domain)
 
 #### References
 
-- **account *(Optional)*:** CAIP-10 account 
-- **domain *(Optional)*:** Domain of dapp
+- **account _(Optional)_:** CAIP-10 account
+- **domain _(Optional)_:** Domain of dapp
 - **messages:** Array of messages, of type
 
 ```ts
@@ -354,20 +376,17 @@ Manage and fetch subscription scopes.
 
 <PlatformTabs
 	groupId="w3iw"
-	activeOptions={["react", "javascript"]}
+	activeOptions={["react", "js"]}
 >
 
 <PlatformTabItem value="react">
 
 ```ts
-
-
 // watch and manage scopes of current account's subscription to current dapp
 const { scopes, updateScopes } = useSubscriptionScopes()
 
 // watch and manage scopes of specific account's subscription to current dapp
 const { scopes, updateScopes } = useSubscriptionScopes(account)
-
 
 // watch and manage scopes of specific account's subscription to specific dapp
 const { scopes, updateScopes } = useSubscriptionScopes(account, domain)
@@ -377,8 +396,8 @@ updateScopes(Object.keys(scopes))
 
 #### References
 
-- **account *(Optional)*:** CAIP-10 account 
-- **domain *(Optional)*:** dapp domain
+- **account _(Optional)_:** CAIP-10 account
+- **domain _(Optional)_:** dapp domain
 - **scopes:** Map of scopes (Notification types)
 - **updateScopes:** `(enabledScopeNames: string[]) -> void`
 
@@ -394,10 +413,9 @@ type ScopeMap = Record<
 ```
 
 </PlatformTabItem>
-<PlatformTabItem value="javascript">
+<PlatformTabItem value="js">
 
 ```ts
-
 // get scopes of current account's subscription to current dapp
 const scopes = client.getNotificationTypes()
 
@@ -406,7 +424,6 @@ const scopes = client.getNotificationTypes(account)
 
 // get scopes of specific account's subscription to specific dapp
 const scopes = client.getNotificationTypes(account, domain)
-
 
 let reactiveScopes = {}
 
@@ -431,8 +448,8 @@ client.update(Object.keys(scopes), account, domain)
 
 #### References
 
-- **account *(Optional)*:** CAIP-10 account 
-- **domain *(Optional)*:** dapp domain
+- **account _(Optional)_:** CAIP-10 account
+- **domain _(Optional)_:** dapp domain
 - **scopes:** Map of scopes (Notification types)
 - **updateScopes:** `(enabledScopeNames: string[]) -> void`
 

--- a/docs/web3inbox/frontend-integration/api.mdx
+++ b/docs/web3inbox/frontend-integration/api.mdx
@@ -18,7 +18,7 @@ Furthremore you may need to configure the `domain` and `isLimited` parameters:
 
 <PlatformTabs
 	groupId="w3iw"
-	activeOptions={["react", "js"]}
+	activeOptions={["react", "javascript"]}
 >
 
 <PlatformTabItem value="react">
@@ -35,7 +35,7 @@ const isReady = useInitWeb3inboxClient({ projectId, domain, isLimited })
 
 </PlatformTabItem>
 
-<PlatformTabItem value="js">
+<PlatformTabItem value="javascript">
 
 ```ts
 const client = await Web3InboxClient.init({ projectId, domain, isLimited })
@@ -61,7 +61,7 @@ account is already registered. This is to enable state synchronization.
 
 <PlatformTabs
 	groupId="w3iw"
-	activeOptions={["react", "js"]}
+	activeOptions={["react", "javascript"]}
 >
 
 <PlatformTabItem value="react">
@@ -99,7 +99,7 @@ Some suggested ways to implement the `onSign` callback are via:
 
 </PlatformTabItem>
 
-<PlatformTabItem value="js">
+<PlatformTabItem value="javascript">
 
 ```ts
 await client.setAccount('eip155:1:0x9AfEaC202C837df470b5A145e0EfD6a574B21029')
@@ -143,7 +143,7 @@ Subscribe, Unsubscribe, Get Subscription, Check if Subscribed.
 
 <PlatformTabs
 	groupId="w3iw"
-	activeOptions={["react", "js"]}
+	activeOptions={["react", "javascript"]}
 >
 
 <PlatformTabItem value="react">
@@ -202,7 +202,7 @@ const subscriptions = useSubscriptions(account)
 - **subscriptions:** Reactive state, returning array of current subscriptions
 
 </PlatformTabItem>
-<PlatformTabItem value="js">
+<PlatformTabItem value="javascript">
 
 ```ts
 // check if current account is subscribed to current dapp
@@ -302,7 +302,7 @@ Get and delete messages
 
 <PlatformTabs
 	groupId="w3iw"
-	activeOptions={["react", "js"]}
+	activeOptions={["react", "javascript"]}
 >
 
 <PlatformTabItem value="react">
@@ -336,7 +336,7 @@ deleteMessage(messages[0].id)
 ```
 
 </PlatformTabItem>
-<PlatformTabItem value="js">
+<PlatformTabItem value="javascript">
 
 ```ts
 const nonReactiveMessageState = client.getMessageHistory(account)
@@ -376,7 +376,7 @@ Manage and fetch subscription scopes.
 
 <PlatformTabs
 	groupId="w3iw"
-	activeOptions={["react", "js"]}
+	activeOptions={["react", "javascript"]}
 >
 
 <PlatformTabItem value="react">
@@ -413,7 +413,7 @@ type ScopeMap = Record<
 ```
 
 </PlatformTabItem>
-<PlatformTabItem value="js">
+<PlatformTabItem value="javascript">
 
 ```ts
 // get scopes of current account's subscription to current dapp

--- a/docs/web3inbox/frontend-integration/usage.mdx
+++ b/docs/web3inbox/frontend-integration/usage.mdx
@@ -18,7 +18,7 @@ Before begin using Web3Inbox, you will first need to [setup your domain](../doma
 
 <PlatformTabs
 	groupId="w3iw"
-	activeOptions={["react", "js"]}
+	activeOptions={["react", "javascript"]}
 >
 <PlatformTabItem value="react">
 
@@ -27,7 +27,7 @@ npm i @web3inbox/core @web3inbox/widget-react
 ```
 
 </PlatformTabItem>
-<PlatformTabItem value="js">
+<PlatformTabItem value="javascript">
 
 ```bash npm2yarn
 npm i @web3inbox/core
@@ -42,7 +42,7 @@ This basic example demonstrates how to use the Web3Inbox SDK to subscribe to not
 
 <PlatformTabs
 	groupId="w3iw"
-	activeOptions={["react", "js"]}
+	activeOptions={["react", "javascript"]}
 >
 <PlatformTabItem value="react">
 
@@ -154,7 +154,7 @@ export default function App() {
 ```
 
 </PlatformTabItem>
-<PlatformTabItem value="js">
+<PlatformTabItem value="javascript">
 
 ```ts
 import { Web3InboxClient } from '@web3inbox/core'

--- a/docs/web3inbox/frontend-integration/usage.mdx
+++ b/docs/web3inbox/frontend-integration/usage.mdx
@@ -161,23 +161,27 @@ import { Web3InboxClient } from '@web3inbox/core'
 
 const client = await Web3InboxClient.init({ projectId: '...' })
 
-let accountState = ''
-let subscriptionState = ''
+// Setup the register hook. Whenever account changes, and on startup, we need to re-register.
+client.watchAccount(account => {
+  client.register({
+    account,
+    onSign,
+  })
+})
 
-client.register({ onSign })
+// Set the account to a CAIP-10 account ID
+await client.setAccount('eip155:1:0x9AfEaC202C837df470b5A145e0EfD6a574B21029')
 
-client.watchAccount(acc => (accountState = acc))
+// Get the current notification subscription or watch for updates
+const subscription = client.getSubscription()
+client.watchSubscription(subscription => console.log({ subscription }))
 
-client.watchSubscription(sub => (subscriptionState = sub))
+// Subscribe to the app
+await client.subscribeToDapp()
 
-client.subscribe()
-
+// Get notification history
 const messages = client.getMessageHistory()
 ```
 
 </PlatformTabItem>
 </PlatformTabs>
-
-## Next Steps
-
-Now that you've installed Web3Inbox Core and set it up, you're ready to use the API.

--- a/docs/web3inbox/sending-notifications.mdx
+++ b/docs/web3inbox/sending-notifications.mdx
@@ -30,7 +30,7 @@ Example usage:
 
 <Tabs queryString={'api-client'}>
 
-<TabItem value="javascript" label="JavaScript">
+<TabItem value="js" label="JavaScript">
 
 ```javascript
 const PROJECT_ID = "<PROJECT_ID>";
@@ -89,7 +89,7 @@ You can get a list of all of the currently-subscribed accounts by calling the `/
 
 <Tabs queryString={'api-client'}>
 
-<TabItem value="javascript" label="JavaScript">
+<TabItem value="js" label="JavaScript">
 
 ```typescript
 const PROJECT_ID = "<PROJECT_ID>";

--- a/docs/web3inbox/sending-notifications.mdx
+++ b/docs/web3inbox/sending-notifications.mdx
@@ -30,7 +30,7 @@ Example usage:
 
 <Tabs queryString={'api-client'}>
 
-<TabItem value="js" label="JavaScript">
+<TabItem value="javascript" label="JavaScript">
 
 ```javascript
 const PROJECT_ID = "<PROJECT_ID>";
@@ -89,7 +89,7 @@ You can get a list of all of the currently-subscribed accounts by calling the `/
 
 <Tabs queryString={'api-client'}>
 
-<TabItem value="js" label="JavaScript">
+<TabItem value="javascript" label="JavaScript">
 
 ```typescript
 const PROJECT_ID = "<PROJECT_ID>";

--- a/docs/web3modal/upgrade.mdx
+++ b/docs/web3modal/upgrade.mdx
@@ -18,7 +18,7 @@ import PlatformTabItem from '../components/PlatformTabItem'
 
 <PlatformTabs
 	groupId="w3m"
-	activeOptions={["react", "js"]}
+	activeOptions={["react", "javascript"]}
 >
 <PlatformTabItem value="react">
 
@@ -30,7 +30,7 @@ npm install @web3modal/wagmi
 ```
 
 </PlatformTabItem>
-<PlatformTabItem value="js">
+<PlatformTabItem value="javascript">
 
 To upgrade from Web3Modal v2 to v3 start by removing Web3Modal v2 dependencies `@web3modal/ethereum` and `@web3modal/html`,
 while keeping `@wagmi/core` and `viem` installed. Now you can install Web3Modal v3 library
@@ -46,7 +46,7 @@ npm install @web3modal/wagmi
 
 <PlatformTabs
 	groupId="w3m"
-	activeOptions={["react", "js"]}
+	activeOptions={["react", "javascript"]}
 >
 <PlatformTabItem value="react">
 
@@ -222,7 +222,7 @@ export default function App() {
 </Tabs>
 
 </PlatformTabItem>
-<PlatformTabItem value="js">
+<PlatformTabItem value="javascript">
 
 Start by importing Web3Modal and wagmi packages, then create wagmi config using your own settings or our default presets as shown below. Finally, pass wagmi config to Web3Modal as ethereumClient.
 
@@ -366,7 +366,7 @@ Finally, pass `wagmiConfig` to `createWeb3Modal`
 
 <PlatformTabs
 	groupId="w3m"
-	activeOptions={["react", "js"]}
+	activeOptions={["react", "javascript"]}
 >
 <PlatformTabItem value="react">
 
@@ -388,7 +388,7 @@ function HomePage() {
 Learn more about Web3Modal v3 [here](./react/about.mdx)
 
 </PlatformTabItem>
-<PlatformTabItem value="js">
+<PlatformTabItem value="javascript">
 
 
 Use your own button with to open the modal

--- a/docs/web3modal/upgrade.mdx
+++ b/docs/web3modal/upgrade.mdx
@@ -18,7 +18,7 @@ import PlatformTabItem from '../components/PlatformTabItem'
 
 <PlatformTabs
 	groupId="w3m"
-	activeOptions={["react","javascript"]}
+	activeOptions={["react", "js"]}
 >
 <PlatformTabItem value="react">
 
@@ -30,7 +30,7 @@ npm install @web3modal/wagmi
 ```
 
 </PlatformTabItem>
-<PlatformTabItem value="javascript">
+<PlatformTabItem value="js">
 
 To upgrade from Web3Modal v2 to v3 start by removing Web3Modal v2 dependencies `@web3modal/ethereum` and `@web3modal/html`,
 while keeping `@wagmi/core` and `viem` installed. Now you can install Web3Modal v3 library
@@ -46,7 +46,7 @@ npm install @web3modal/wagmi
 
 <PlatformTabs
 	groupId="w3m"
-	activeOptions={["react","javascript"]}
+	activeOptions={["react", "js"]}
 >
 <PlatformTabItem value="react">
 
@@ -222,7 +222,7 @@ export default function App() {
 </Tabs>
 
 </PlatformTabItem>
-<PlatformTabItem value="javascript">
+<PlatformTabItem value="js">
 
 Start by importing Web3Modal and wagmi packages, then create wagmi config using your own settings or our default presets as shown below. Finally, pass wagmi config to Web3Modal as ethereumClient.
 
@@ -366,7 +366,7 @@ Finally, pass `wagmiConfig` to `createWeb3Modal`
 
 <PlatformTabs
 	groupId="w3m"
-	activeOptions={["react","javascript"]}
+	activeOptions={["react", "js"]}
 >
 <PlatformTabItem value="react">
 
@@ -388,7 +388,7 @@ function HomePage() {
 Learn more about Web3Modal v3 [here](./react/about.mdx)
 
 </PlatformTabItem>
-<PlatformTabItem value="javascript">
+<PlatformTabItem value="js">
 
 
 Use your own button with to open the modal

--- a/docs/web3wallet/notify/usage.mdx
+++ b/docs/web3wallet/notify/usage.mdx
@@ -441,7 +441,7 @@ const onSign = (message: string) => ethersWallet.signMessage(message)
 await notifyClient.register({
   account,
   onSign,
-  domain: 'app.mydomain.com', // pass the domain (i.e. the hostname) where your dapp is hosted.
+  domain: 'app.example.com', // pass the domain (i.e. the hostname) where your dapp is hosted.
   isLimited: true // The user will be prompted to authorize this dapp to send and receive messages on their behalf for this domain using their WalletConnect identity.
 })
 ```
@@ -455,7 +455,7 @@ const onSign = (message: string) => ethersWallet.signMessage(message)
 await notifyClient.register({
   account,
   onSign,
-  domain: 'com.mydomain.app.rn', // pass your app's bundle identifier.
+  domain: 'com.example.app.rn', // pass your app's bundle identifier.
   isLimited: false // The user will be prompted to authorize this wallet to send and receive messages on their behalf for ALL domains using their WalletConnect identity.
 })
 ```


### PR DESCRIPTION
- Add more context and clarification around `domain` and `isLimited`
- Call `register()` when account changes
- Remove `const client = useWeb3InboxClient()` from hooks example as this is not intended to be used
- Add more missing `await`s and fix various function calls
- Remove "reactive" variables in-favor of `console.log()` for simplicity
- Add `watchSubscription()` to API
- Prefer `example.com` as example domains, rather than `mydomain.com` or the like, since it is an official example domain
- Prefer `javascript` over `js` for selecting language
- Use an actual example address `0x9AfEaC202C837df470b5A145e0EfD6a574B21029` instead of `...` or `0xFFF...`. This is same address from Notify Server API docs, and was randomly generated in the browser and private key not saved so this is guaranteed to never be used.