### PR TITLE
fix: markprompt dialog z-index

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1156,6 +1156,11 @@ article img {
     display: none;
   }
 }
+
+:where(.MarkpromptContentDialog) {
+  z-index: 200;
+}
+
 /* End - HomePage */
 
 /* Start - Sidebar */


### PR DESCRIPTION
<img width="996" alt="image" src="https://github.com/WalletConnect/walletconnect-docs/assets/26746725/0b13a6db-6659-4990-a097-30df8134341c">
