### PR TITLE
add advanced folder for web-examples link path

### DIFF
--- a/docs/advanced/migration-from-v1.x/dapps/dapp-checklist.md
+++ b/docs/advanced/migration-from-v1.x/dapps/dapp-checklist.md
@@ -14,7 +14,7 @@ Our primary example of a WalletConnect v2.0 dapp is linked [here](https://react-
 - `connect`
 - `disconnect`
 
-The source code for this WalletConnect v2.0 dapp is [here](https://github.com/WalletConnect/web-examples/tree/main/dapps/react-dapp-v2).
+The source code for this WalletConnect v2.0 dapp is [here](https://github.com/WalletConnect/web-examples/tree/main/advanced/dapps/react-dapp-v2).
 
 ## Required and Optional Namespaces and Methods
 

--- a/docs/advanced/migration-from-v1.x/wallets/wallet-checklist.md
+++ b/docs/advanced/migration-from-v1.x/wallets/wallet-checklist.md
@@ -18,7 +18,7 @@ Please note that the links to SDK versions and sample wallets can be found in th
 
 **Sample wallets:**
 
-🌐 [Web GitHub Repo](https://github.com/WalletConnect/web-examples/tree/main/wallets/react-web3wallet)
+🌐 [Web GitHub Repo](https://github.com/WalletConnect/web-examples/tree/main/advanced/wallets/react-web3wallet)
 
 🤖 [Android GitHub Repo](https://github.com/WalletConnect/WalletConnectKotlinV2/tree/develop/sample/wallet)
 

--- a/docs/advanced/multichain/overview.md
+++ b/docs/advanced/multichain/overview.md
@@ -23,12 +23,12 @@ Integrate RPC method support into the example wallets and dapp.
 **Example Wallet**
 
 - [Demo](https://react-web3wallet.vercel.app/)
-- [GitHub](https://github.com/WalletConnect/web-examples/tree/main/wallets/react-web3wallet)
+- [GitHub](https://github.com/WalletConnect/web-examples/tree/main/advanced/wallets/react-web3wallet)
 
 **Example Dapp**
 
 - [Demo](https://react-app.walletconnect.com/)
-- [GitHub](https://github.com/WalletConnect/web-examples/tree/main/dapps/react-dapp-v2)
+- [GitHub](https://github.com/WalletConnect/web-examples/tree/main/advanced/dapps/react-dapp-v2)
 
 ## Promote
 

--- a/docs/advanced/multichain/polkadot/namespaces-guide.md
+++ b/docs/advanced/multichain/polkadot/namespaces-guide.md
@@ -96,7 +96,7 @@ An example Proposal Namespace for a dapp which supports connecting to Polkadot, 
 
 - `methods` is represented as an array of wallet defined methods that a session supports.
 - These are not pre-defined or centrally implemented and can be modified/extended as needed by a wallet.
-- In the above Polkadot session namespace example there are two given methods `polkadot_signMessage` and `polkadot_signTransaction`. The idea for the functionality of these methods is to sign the relevant data (either a message or unsigned transaction) and return the signature. [An example for each method](https://github.com/WalletConnect/web-examples/blob/main/wallets/react-wallet-v2/src/lib/PolkadotLib.ts).
+- In the above Polkadot session namespace example there are two given methods `polkadot_signMessage` and `polkadot_signTransaction`. The idea for the functionality of these methods is to sign the relevant data (either a message or unsigned transaction) and return the signature. [An example for each method](https://github.com/WalletConnect/web-examples/blob/main/advanced/wallets/react-wallet-v2/src/lib/PolkadotLib.ts).
 - If a dapp required additional method support such as receiving the signed hex for a transaction in order to submit it rather than the signature, a wallet only needs to define and add support for the method so that any dapp that requires that functionality can use it when making requests.
 - An example would be adding a method named `polkadot_getSignedHex` and creating an implementation that signs, and returns the hash of the signed transaction.
 

--- a/docs/advanced/multichain/polkadot/wallet-integration-guide.md
+++ b/docs/advanced/multichain/polkadot/wallet-integration-guide.md
@@ -116,7 +116,7 @@ web3wallet.on('session_proposal', async proposal => {
 
 # Handling Session Request Event
 
-A dapp triggers an event when it requires the wallet to carry out a specific action, such as signing a transaction. The event includes a topic and a request object, which will differ based on the requested action. As seen in the [WalletConnect Web Examples](https://github.com/WalletConnect/web-examples/blob/main/wallets/react-wallet-v2/src/lib/PolkadotLib.ts), two common use cases in polkadot are signing messages and signing transactions. These methods are represented here as `polkadot_signMessage` and `polkadot_signTransaction` respectively and each simply signs the respective payload and returns the signature to the dapp. An example of a `session_request` event handler containing both can be found below.
+A dapp triggers an event when it requires the wallet to carry out a specific action, such as signing a transaction. The event includes a topic and a request object, which will differ based on the requested action. As seen in the [WalletConnect Web Examples](https://github.com/WalletConnect/web-examples/blob/main/advanced/wallets/react-wallet-v2/src/lib/PolkadotLib.ts), two common use cases in polkadot are signing messages and signing transactions. These methods are represented here as `polkadot_signMessage` and `polkadot_signTransaction` respectively and each simply signs the respective payload and returns the signature to the dapp. An example of a `session_request` event handler containing both can be found below.
 
 ```js
 web3wallet.on('session_request', async requestEvent => {

--- a/docs/api/auth/dapp-usage.md
+++ b/docs/api/auth/dapp-usage.md
@@ -17,7 +17,7 @@ activeOptions={["web","ios","android","flutter","csharp"]}>
 <PlatformTabItem value="web">
 
 :::info
-For an example implementation, please refer to our [`react-dapp-auth` example](https://github.com/WalletConnect/web-examples/tree/main/dapps/react-dapp-auth).
+For an example implementation, please refer to our [`react-dapp-auth` example](https://github.com/WalletConnect/web-examples/tree/main/advanced/dapps/react-dapp-auth).
 :::
 
 **1. Initialize your WalletConnect AuthClient, using [your Project ID](../../cloud/relay.md).**

--- a/docs/api/auth/wallet-usage.md
+++ b/docs/api/auth/wallet-usage.md
@@ -17,7 +17,7 @@ activeOptions={["web","ios","android","csharp"]}>
 <PlatformTabItem value="web">
 
 :::info
-For an example implementation, please refer to our [`react-wallet-auth` example](https://github.com/WalletConnect/web-examples/tree/main/wallets/react-wallet-auth).
+For an example implementation, please refer to our [`react-wallet-auth` example](https://github.com/WalletConnect/web-examples/tree/main/advanced/wallets/react-wallet-auth).
 :::
 
 **1. Initialize your WalletConnect AuthClient, using [your Project ID](../../cloud/relay.md).**

--- a/docs/api/chat/resources.mdx
+++ b/docs/api/chat/resources.mdx
@@ -7,4 +7,4 @@ Valuable assets for developers and users interested in integrating chat API into
 
 <!--Todo: Prettify this section-->
 
-- [React Chat Wallet](https://github.com/WalletConnect/web-examples/tree/main/wallets/react-wallet-chat) ([Demo](https://react-wallet-chat.walletconnect.com/))
+- [React Chat Wallet](https://github.com/WalletConnect/web-examples/tree/main/advanced/wallets/react-wallet-chat) ([Demo](https://react-wallet-chat.walletconnect.com/))

--- a/docs/api/chat/usage.mdx
+++ b/docs/api/chat/usage.mdx
@@ -15,7 +15,7 @@ import PlatformTabItem from '../../components/PlatformTabItem'
 <PlatformTabItem value="web">
 
 :::info
-For an example implementation, please refer to our [react-wallet-chat example](https://github.com/WalletConnect/web-examples/tree/main/wallets/react-wallet-chat) and [demo](https://react-wallet-chat.walletconnect.com/)
+For an example implementation, please refer to our [react-wallet-chat example](https://github.com/WalletConnect/web-examples/tree/main/advanced/wallets/react-wallet-chat) and [demo](https://react-wallet-chat.walletconnect.com/)
 :::
 
 #### Initialize your WalletConnect ChatClient, using your Project ID

--- a/docs/api/sign/dapp-usage.md
+++ b/docs/api/sign/dapp-usage.md
@@ -22,7 +22,7 @@ npm install @walletconnect/modal
 ```
 
 :::info
-For an example implementation, please refer to our `react-dapp-v2` [example](https://github.com/WalletConnect/web-examples/tree/main/dapps/react-dapp-v2).
+For an example implementation, please refer to our `react-dapp-v2` [example](https://github.com/WalletConnect/web-examples/tree/main/advanced/dapps/react-dapp-v2).
 :::
 
 #### Install Packages

--- a/docs/api/sign/wallet-usage.md
+++ b/docs/api/sign/wallet-usage.md
@@ -216,7 +216,7 @@ await signClient.reject({
 
 #### Pairing with QR Codes
 
-To facilitate better user experience, it is possible to pair wallets with dapps by scanning QR codes. This can be implemented by using any QR code scanning library (example, [react-qr-reader](https://www.npmjs.com/package/react-qr-reader)). After scanning the QR code, pass the obtained `uri` into the `signClient.pair()` function. A useful reference for implementing QR codes for pairing is the [react wallet example](https://github.com/WalletConnect/web-examples/blob/main/wallets/react-wallet-v2/).
+To facilitate better user experience, it is possible to pair wallets with dapps by scanning QR codes. This can be implemented by using any QR code scanning library (example, [react-qr-reader](https://www.npmjs.com/package/react-qr-reader)). After scanning the QR code, pass the obtained `uri` into the `signClient.pair()` function. A useful reference for implementing QR codes for pairing is the [react wallet example](https://github.com/WalletConnect/web-examples/blob/main/advanced/wallets/react-wallet-v2/).
 
 </PlatformTabItem>
 

--- a/docs/web3wallet/resources.mdx
+++ b/docs/web3wallet/resources.mdx
@@ -23,19 +23,19 @@ We have a set of official examples in our [web-examples](https://github.com/Wall
 
 This wallet can be used with any dapp using Sign v2 or Auth.
 
-- [React Web3Wallet](https://github.com/WalletConnect/web-examples/tree/main/wallets/react-web3wallet) ([Demo](https://react-web3wallet.vercel.app))
+- [React Web3Wallet](https://github.com/WalletConnect/web-examples/tree/main/advanced/wallets/react-web3wallet) ([Demo](https://react-web3wallet.vercel.app))
 
 **Sign**
 
-- [React Wallet Ethers - v2](https://github.com/WalletConnect/web-examples/tree/main/wallets/react-wallet-v2) ([Demo](https://react-wallet.walletconnect.com/))
+- [React Wallet Ethers - v2](https://github.com/WalletConnect/web-examples/tree/main/advanced/wallets/react-wallet-v2) ([Demo](https://react-wallet.walletconnect.com/))
 
 **Auth**
 
-- [React Auth Wallet](https://github.com/WalletConnect/web-examples/tree/main/wallets/react-wallet-auth) ([Demo](https://react-auth-wallet.vercel.app/))
+- [React Auth Wallet](https://github.com/WalletConnect/web-examples/tree/main/advanced/wallets/react-wallet-auth) ([Demo](https://react-auth-wallet.vercel.app/))
 
 **Chat**
 
-- [React Chat Wallet](https://github.com/WalletConnect/web-examples/tree/main/wallets/react-wallet-chat) ([Demo](https://react-wallet-chat.walletconnect.com/))
+- [React Chat Wallet](https://github.com/WalletConnect/web-examples/tree/main/advanced/wallets/react-wallet-chat) ([Demo](https://react-wallet-chat.walletconnect.com/))
 
 </PlatformTabItem>
 <PlatformTabItem value="ios">
@@ -46,15 +46,15 @@ If you need to test your app's integration, you can use one of our following dem
 
 **Sign**
 
-- [React Wallet Ethers - v2](https://github.com/WalletConnect/web-examples/tree/main/wallets/react-wallet-v2) ([Demo](https://react-wallet.walletconnect.com/))
+- [React Wallet Ethers - v2](https://github.com/WalletConnect/web-examples/tree/main/advanced/wallets/react-wallet-v2) ([Demo](https://react-wallet.walletconnect.com/))
 
 **Auth**
 
-- [React Auth Wallet](https://github.com/WalletConnect/web-examples/tree/main/wallets/react-wallet-auth) ([Demo](https://react-auth-wallet.vercel.app/))
+- [React Auth Wallet](https://github.com/WalletConnect/web-examples/tree/main/advanced/wallets/react-wallet-auth) ([Demo](https://react-auth-wallet.vercel.app/))
 
 **Chat**
 
-- [React Chat Wallet](https://github.com/WalletConnect/web-examples/tree/main/wallets/react-wallet-chat) ([Demo](https://react-wallet-chat.walletconnect.com/))
+- [React Chat Wallet](https://github.com/WalletConnect/web-examples/tree/main/advanced/wallets/react-wallet-chat) ([Demo](https://react-wallet-chat.walletconnect.com/))
 
 </PlatformTabItem>
 <PlatformTabItem value="android">
@@ -65,15 +65,15 @@ If you need to test your app's integration, you can use one of our following dem
 
 **Sign**
 
-- [React Wallet Ethers - v2](https://github.com/WalletConnect/web-examples/tree/main/wallets/react-wallet-v2) ([Demo](https://react-wallet.walletconnect.com/))
+- [React Wallet Ethers - v2](https://github.com/WalletConnect/web-examples/tree/main/advanced/wallets/react-wallet-v2) ([Demo](https://react-wallet.walletconnect.com/))
 
 **Auth**
 
-- [React Auth Wallet](https://github.com/WalletConnect/web-examples/tree/main/wallets/react-wallet-auth) ([Demo](https://react-auth-wallet.vercel.app/))
+- [React Auth Wallet](https://github.com/WalletConnect/web-examples/tree/main/advanced/wallets/react-wallet-auth) ([Demo](https://react-auth-wallet.vercel.app/))
 
 **Chat**
 
-- [React Chat Wallet](https://github.com/WalletConnect/web-examples/tree/main/wallets/react-wallet-chat) ([Demo](https://react-wallet-chat.walletconnect.com/))
+- [React Chat Wallet](https://github.com/WalletConnect/web-examples/tree/main/advanced/wallets/react-wallet-chat) ([Demo](https://react-wallet-chat.walletconnect.com/))
 
 </PlatformTabItem>
 
@@ -105,14 +105,14 @@ If you need to test your app's integration, you can use one of our following dem
 
 **Sign**
 
-- [React dApp (with standalone client) - v2](https://github.com/WalletConnect/web-examples/tree/main/dapps/react-dapp-v2) ([Demo](https://react-app.walletconnect.com/))
-- [React dApp (with EthereumProvider + Ethers.js) - v2](https://github.com/WalletConnect/web-examples/tree/main/dapps/react-dapp-v2-with-ethers) ([Demo](https://react-dapp-v2-with-ethers.vercel.app/))
-- [React dApp (with EthereumProvider + web3.js) - v2](https://github.com/WalletConnect/web-examples/tree/main/dapps/react-dapp-v2-with-web3js) ([Demo](https://react-dapp-v2-with-web3js.vercel.app/))
-- [React dApp (with CosmosProvider) - v2](https://github.com/WalletConnect/web-examples/tree/main/dapps/react-dapp-v2-cosmos-provider) ([Demo](https://react-dapp-v2-cosmos-provider.vercel.app/))
+- [React dApp (with standalone client) - v2](https://github.com/WalletConnect/web-examples/tree/main/advanced/dapps/react-dapp-v2) ([Demo](https://react-app.walletconnect.com/))
+- [React dApp (with EthereumProvider + Ethers.js) - v2](https://github.com/WalletConnect/web-examples/tree/main/advanced/dapps/react-dapp-v2-with-ethers) ([Demo](https://react-dapp-v2-with-ethers.vercel.app/))
+- [React dApp (with EthereumProvider + web3.js) - v2](https://github.com/WalletConnect/web-examples/tree/main/advanced/dapps/react-dapp-v2-with-web3js) ([Demo](https://react-dapp-v2-with-web3js.vercel.app/))
+- [React dApp (with CosmosProvider) - v2](https://github.com/WalletConnect/web-examples/tree/main/advanced/dapps/react-dapp-v2-cosmos-provider) ([Demo](https://react-dapp-v2-cosmos-provider.vercel.app/))
 
 **Auth**
 
-- [React dApp (with auth client)](https://github.com/WalletConnect/web-examples/tree/main/dapps/react-dapp-auth) ([Demo](https://react-auth-dapp.vercel.app/))
+- [React dApp (with auth client)](https://github.com/WalletConnect/web-examples/tree/main/advanced/dapps/react-dapp-auth) ([Demo](https://react-auth-dapp.vercel.app/))
 
 </PlatformTabItem>
 <PlatformTabItem value="ios">
@@ -121,14 +121,14 @@ Sample Wallet and Dapp sample apps can be found under the Example directory in [
 
 **Sign**
 
-- [React dApp (with standalone client) - v2](https://github.com/WalletConnect/web-examples/tree/main/dapps/react-dapp-v2) ([Demo](https://react-app.walletconnect.com/))
-- [React dApp (with EthereumProvider + Ethers.js) - v2](https://github.com/WalletConnect/web-examples/tree/main/dapps/react-dapp-v2-with-ethers) ([Demo](https://react-dapp-v2-with-ethers.vercel.app/))
-- [React dApp (with EthereumProvider + web3.js) - v2](https://github.com/WalletConnect/web-examples/tree/main/dapps/react-dapp-v2-with-web3js) ([Demo](https://react-dapp-v2-with-web3js.vercel.app/))
-- [React dApp (with CosmosProvider) - v2](https://github.com/WalletConnect/web-examples/tree/main/dapps/react-dapp-v2-cosmos-provider) ([Demo](https://react-dapp-v2-cosmos-provider.vercel.app/))
+- [React dApp (with standalone client) - v2](https://github.com/WalletConnect/web-examples/tree/main/advanced/dapps/react-dapp-v2) ([Demo](https://react-app.walletconnect.com/))
+- [React dApp (with EthereumProvider + Ethers.js) - v2](https://github.com/WalletConnect/web-examples/tree/main/advanced/dapps/react-dapp-v2-with-ethers) ([Demo](https://react-dapp-v2-with-ethers.vercel.app/))
+- [React dApp (with EthereumProvider + web3.js) - v2](https://github.com/WalletConnect/web-examples/tree/main/advanced/dapps/react-dapp-v2-with-web3js) ([Demo](https://react-dapp-v2-with-web3js.vercel.app/))
+- [React dApp (with CosmosProvider) - v2](https://github.com/WalletConnect/web-examples/tree/main/advanced/dapps/react-dapp-v2-cosmos-provider) ([Demo](https://react-dapp-v2-cosmos-provider.vercel.app/))
 
 **Auth**
 
-- [React dApp (with auth client)](https://github.com/WalletConnect/web-examples/tree/main/dapps/react-dapp-auth) ([Demo](https://react-auth-dapp.vercel.app/))
+- [React dApp (with auth client)](https://github.com/WalletConnect/web-examples/tree/main/advanced/dapps/react-dapp-auth) ([Demo](https://react-auth-dapp.vercel.app/))
 
 </PlatformTabItem>
 <PlatformTabItem value="android">
@@ -137,14 +137,14 @@ Sample Wallet and Dapp .apk files can be found under the latest release tag in [
 
 **Sign**
 
-- [React dApp (with standalone client) - v2](https://github.com/WalletConnect/web-examples/tree/main/dapps/react-dapp-v2) ([Demo](https://react-app.walletconnect.com/))
-- [React dApp (with EthereumProvider + Ethers.js) - v2](https://github.com/WalletConnect/web-examples/tree/main/dapps/react-dapp-v2-with-ethers) ([Demo](https://react-dapp-v2-with-ethers.vercel.app/))
-- [React dApp (with EthereumProvider + web3.js) - v2](https://github.com/WalletConnect/web-examples/tree/main/dapps/react-dapp-v2-with-web3js) ([Demo](https://react-dapp-v2-with-web3js.vercel.app/))
-- [React dApp (with CosmosProvider) - v2](https://github.com/WalletConnect/web-examples/tree/main/dapps/react-dapp-v2-cosmos-provider) ([Demo](https://react-dapp-v2-cosmos-provider.vercel.app/))
+- [React dApp (with standalone client) - v2](https://github.com/WalletConnect/web-examples/tree/main/advanced/dapps/react-dapp-v2) ([Demo](https://react-app.walletconnect.com/))
+- [React dApp (with EthereumProvider + Ethers.js) - v2](https://github.com/WalletConnect/web-examples/tree/main/advanced/dapps/react-dapp-v2-with-ethers) ([Demo](https://react-dapp-v2-with-ethers.vercel.app/))
+- [React dApp (with EthereumProvider + web3.js) - v2](https://github.com/WalletConnect/web-examples/tree/main/advanced/dapps/react-dapp-v2-with-web3js) ([Demo](https://react-dapp-v2-with-web3js.vercel.app/))
+- [React dApp (with CosmosProvider) - v2](https://github.com/WalletConnect/web-examples/tree/main/advanced/dapps/react-dapp-v2-cosmos-provider) ([Demo](https://react-dapp-v2-cosmos-provider.vercel.app/))
 
 **Auth**
 
-- [React dApp (with auth client)](https://github.com/WalletConnect/web-examples/tree/main/dapps/react-dapp-auth) ([Demo](https://react-auth-dapp.vercel.app/))
+- [React dApp (with auth client)](https://github.com/WalletConnect/web-examples/tree/main/advanced/dapps/react-dapp-auth) ([Demo](https://react-auth-dapp.vercel.app/))
 
 </PlatformTabItem>
 </PlatformTabs>

--- a/docs/web3wallet/wallet-usage.mdx
+++ b/docs/web3wallet/wallet-usage.mdx
@@ -584,7 +584,7 @@ await web3wallet.pair({ uri })
 
 #### 🛠️ Usage examples
 
-- [in a demo wallet app](https://github.com/WalletConnect/web-examples/blob/main/wallets/react-web3wallet/src/views/SessionProposalModal.tsx#L75)
+- [in a demo wallet app](https://github.com/WalletConnect/web-examples/blob/main/advanced/wallets/react-web3wallet/src/views/SessionProposalModal.tsx#L75)
 - [in integration tests](https://github.com/WalletConnect/walletconnect-monorepo/blob/v2.0/packages/web3wallet/test/sign.spec.ts#L55)
 
 #### ⚠️ Expected Errors
@@ -897,7 +897,7 @@ web3wallet.on('session_proposal', async proposal => {
 
 #### 🛠️ Usage examples
 
-- [in a demo wallet app](https://github.com/WalletConnect/web-examples/blob/main/wallets/react-web3wallet/src/views/SessionProposalModal.tsx#L87)
+- [in a demo wallet app](https://github.com/WalletConnect/web-examples/blob/main/advanced/wallets/react-web3wallet/src/views/SessionProposalModal.tsx#L87)
 - [in integration tests](https://github.com/WalletConnect/walletconnect-monorepo/blob/v2.0/packages/web3wallet/test/sign.spec.ts#L79)
 
 #### ⚠️ Expected Errors
@@ -1031,7 +1031,7 @@ const response = {
 
 #### 🛠️ Usage examples
 
-- [in a demo wallet app](https://github.com/WalletConnect/web-examples/blob/main/wallets/react-web3wallet/src/views/SessionSignModal.tsx#L33)
+- [in a demo wallet app](https://github.com/WalletConnect/web-examples/blob/main/advanced/wallets/react-web3wallet/src/views/SessionSignModal.tsx#L33)
 - [in integration tests](https://github.com/WalletConnect/walletconnect-monorepo/blob/v2.0/packages/web3wallet/test/sign.spec.ts#L165)
 
 #### ⚠️ Expected Errors
@@ -1340,7 +1340,7 @@ await web3wallet.updateSession({ topic: session.topic, namespaces: updatedNamesp
 
 #### 🛠️ Usage examples
 
-- [in a demo wallet app](https://github.com/WalletConnect/web-examples/blob/main/wallets/react-web3wallet/src/pages/session.tsx#L73)
+- [in a demo wallet app](https://github.com/WalletConnect/web-examples/blob/main/advanced/wallets/react-web3wallet/src/pages/session.tsx#L73)
 - [in integration tests](https://github.com/WalletConnect/walletconnect-monorepo/blob/v2.0/packages/web3wallet/test/sign.spec.ts#L98)
 
 #### ⚠️ Expected Errors


### PR DESCRIPTION
We want to move low level web examples under an advanced folder
https://github.com/WalletConnect/web-examples