### PR TITLE
Chore: Move Sign API information to the top for Notify

### DIFF
--- a/docs/web3wallet/notify/introduction.mdx
+++ b/docs/web3wallet/notify/introduction.mdx
@@ -2,8 +2,9 @@
 
 :::caution
 Web3Inbox is in beta
-:::
 
+For those integrating notifications related to wallet pairing and sign requests, please check [here](../push-notifications.mdx).
+:::
 
 The WalletConnect Notify API is designed to enhance the interaction between wallet users and dapps by offering a robust notification system. This API empowers wallet developers to implement a dynamic notification experience directly within their wallets. It provides the functionality for users to opt-in to notifications, ensuring they stay informed about critical events and interactions.
 
@@ -19,11 +20,5 @@ Some of the key features of the Notify API include:
 - **Robust Spam Protection**: Users have complete authority over which dapps can send them notifications, effectively eliminating any unsolicited messages from unknown sources. Furthermore, users can fine-tune their preferences to only receive notifications types they are interested in, like new features or some important events occurence.
 - **Chain Agnostic Architecture**: The Notify API is built to be compatible with any blockchain, allowing seamless multi-chain support without the need for writing additional integration code. **As of November 2023, the Notify Server and Clients are equipped to support EVM chains. Plans to extend support to non-EVM chains are in progress and are a significant part of our upcoming development roadmap.**
 
-
-*Example integration*
+_Example integration_
 ![Web3Inbox](/img/web3wallet-notify-screenshots.jpg)
-
-## Sign API Notifications
-
-For developers interested in integrating notifications related to wallet pairing and sign requests, detailed guidance is available [here](../push-notifications.mdx).
-

--- a/docs/web3wallet/notify/introduction.mdx
+++ b/docs/web3wallet/notify/introduction.mdx
@@ -1,7 +1,7 @@
 # Introduction
 
 :::caution
-Web3Inbox is in beta
+Web3Inbox is in beta.
 
 For those integrating notifications related to wallet pairing and sign requests, please check [here](../push-notifications.mdx).
 :::


### PR DESCRIPTION
<img width="860" alt="image" src="https://github.com/WalletConnect/walletconnect-docs/assets/45455218/ec45f940-8078-4762-acf4-e6708142b7ab">
