### PR TITLE
fix: updated lightmode text color in blockquotes

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -132,6 +132,10 @@ html[data-theme='dark'] {
   --ifm-container-background-color: #141414;
 }
 
+html[data-theme='light'] {
+  --ifm-blockquote-color: var(--ifm-color-gray-900);
+}
+
 [data-theme='light'] img[src$='#dark-mode-only'],
 [data-theme='dark'] img[src$='#light-mode-only'] {
   display: none;


### PR DESCRIPTION
<img width="648" alt="image" src="https://github.com/WalletConnect/walletconnect-docs/assets/26746725/87e7efe3-528f-489c-b617-6227117cd1da">
