### PR TITLE
Add ReactNode and Wagmi State import to Web3Modal Docs.

### DIFF
--- a/docs/web3modal/nextjs/wagmi/about/implementation.mdx
+++ b/docs/web3modal/nextjs/wagmi/about/implementation.mdx
@@ -13,9 +13,10 @@ Create a new file called `context/Web3Modal.tsx` or `context/Web3Modal.jsx` (out
 ```tsx
 'use client'
 
+import { ReactNode } from 'react';
 import { createWeb3Modal, defaultWagmiConfig } from '@web3modal/wagmi/react'
 
-import { cookieStorage, createStorage, WagmiProvider } from 'wagmi'
+import { cookieStorage, createStorage, State, WagmiProvider } from 'wagmi'
 import { arbitrum, mainnet } from 'wagmi/chains'
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'


### PR DESCRIPTION
 Updated the Web3Modal NextJS docs to include ReactNode and Wagmi State imports.