### PR TITLE
fix(cloud): syncing blockchain-api limits

### DIFF
--- a/docs/cloud/blockchain-api.md
+++ b/docs/cloud/blockchain-api.md
@@ -25,7 +25,7 @@ No config or setup is needed for Web3Modal integrations. For other usage, see th
 
 ## Limits
 
-The Blockchain API is free for 100k requests/day.
+The Blockchain API is free for 6 million requests per 30 days.
 
 ## Links
 


### PR DESCRIPTION
This PR is syncing the Blockchain-API service limits to the limits from the Cloud app by adjusting limits to 6M requests per month in the docs.