### PR TITLE
fix: incorrect default import

### DIFF
--- a/docs/web3modal/nextjs/wagmi/about/implementation.mdx
+++ b/docs/web3modal/nextjs/wagmi/about/implementation.mdx
@@ -100,7 +100,7 @@ import { headers } from 'next/headers'
 import { cookieToInitialState } from 'wagmi'
 
 import { config } from '@/config'
-import ContextProvider from '@/context'
+import { ContextProvider } from '@/context'
 
 export const metadata: Metadata = {
   title: 'Create Next App',


### PR DESCRIPTION
implementation reference above defines `ContextProvider` as standard export without default declaration so it needs the brackets.