### PR TITLE
chore: add allowlist requirement in email alert

### DIFF
--- a/docs/web3modal/javascript/email/index.mdx
+++ b/docs/web3modal/javascript/email/index.mdx
@@ -5,15 +5,15 @@ title: Email Login
 import PlatformTabs from '../../../components/PlatformTabs'
 import PlatformTabItem from '../../../components/PlatformTabItem'
 
+import EmailAlert from '../../shared/email-alert.mdx'
+
 import WagmiImplementation from './wagmi.mdx'
 import EthersImplementation from './ethers.mdx'
 
 Web3Modal SDK enables passwordless Web3 onboarding (no seed phrases) and authentication.
 It offers blazing-fast, hardware-secured, passwordless login, Web3 onboarding, and access to over 20 blockchains with a few lines of code — even if you have an existing auth solution.
 
-:::caution
-Email Login is currently in Beta
-:::
+<EmailAlert />
 
 <PlatformTabs groupId="eth-lib" activeOptions={["wagmi", "ethers"]}>
 <PlatformTabItem value="wagmi">

--- a/docs/web3modal/nextjs/email/index.mdx
+++ b/docs/web3modal/nextjs/email/index.mdx
@@ -5,15 +5,15 @@ title: Email Login
 import PlatformTabs from '../../../components/PlatformTabs'
 import PlatformTabItem from '../../../components/PlatformTabItem'
 
+import EmailAlert from '../../shared/email-alert.mdx'
+
 import WagmiImplementation from './wagmi.mdx'
 import EthersImplementation from './ethers.mdx'
 
 Web3Modal SDK enables passwordless Web3 onboarding (no seed phrases) and authentication.
 It offers blazing-fast, hardware-secured, passwordless login, Web3 onboarding, and access to over 20 blockchains with a few lines of code — even if you have an existing auth solution.
 
-:::caution
-Email Login is currently in Beta.
-:::
+<EmailAlert />
 
 <PlatformTabs groupId="eth-lib" activeOptions={["wagmi", "ethers"]}>
 <PlatformTabItem value="wagmi">

--- a/docs/web3modal/react/email/index.mdx
+++ b/docs/web3modal/react/email/index.mdx
@@ -5,15 +5,15 @@ title: Email Login
 import PlatformTabs from '../../../components/PlatformTabs'
 import PlatformTabItem from '../../../components/PlatformTabItem'
 
+import EmailAlert from '../../shared/email-alert.mdx'
+
 import WagmiImplementation from './wagmi.mdx'
 import EthersImplementation from './ethers.mdx'
 
 Web3Modal SDK enables passwordless Web3 onboarding (no seed phrases) and authentication.
 It offers blazing-fast, hardware-secured, passwordless login, Web3 onboarding, and access to over 20 blockchains with a few lines of code — even if you have an existing auth solution.
 
-:::caution
-Email Login is currently in Beta.
-:::
+<EmailAlert />
 
 <PlatformTabs groupId="eth-lib" activeOptions={["wagmi", "ethers"]}>
 <PlatformTabItem value="wagmi">

--- a/docs/web3modal/shared/email-alert.mdx
+++ b/docs/web3modal/shared/email-alert.mdx
@@ -1,4 +1,4 @@
 :::caution
 Email Login is currently in Beta. \
-In order to access this feature, your Dapp must be on [allowlist](/cloud/relay#allowlist).
+In order to use this feature you must also configure the [allowlist](/cloud/relay#allowlist) for your app.
 :::

--- a/docs/web3modal/shared/email-alert.mdx
+++ b/docs/web3modal/shared/email-alert.mdx
@@ -1,0 +1,4 @@
+:::caution
+Email Login is currently in Beta. \
+In order to access this feature, your Dapp must be on [allowlist](/cloud/relay#allowlist).
+:::

--- a/docs/web3modal/vue/email/index.mdx
+++ b/docs/web3modal/vue/email/index.mdx
@@ -5,15 +5,15 @@ title: Email Login
 import PlatformTabs from '../../../components/PlatformTabs'
 import PlatformTabItem from '../../../components/PlatformTabItem'
 
+import EmailAlert from '../../shared/email-alert.mdx'
+
 import WagmiImplementation from './wagmi.mdx'
 import EthersImplementation from './ethers.mdx'
 
 Web3Modal SDK enables passwordless Web3 onboarding (no seed phrases) and authentication.
 It offers blazing-fast, hardware-secured, passwordless login, Web3 onboarding, and access to over 20 blockchains with a few lines of code — even if you have an existing auth solution.
 
-:::caution
-Email Login is currently in Beta.
-:::
+<EmailAlert />
 
 <PlatformTabs groupId="eth-lib" activeOptions={["wagmi", "ethers"]}>
 <PlatformTabItem value="wagmi">


### PR DESCRIPTION
Dapps must be on allowlist in order to use emails. Added notification to be clear about it.
