### PR TITLE
Remove unnecessary 'and'

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -120,7 +120,7 @@ It allows you to create, manage and view analytics for your projects. You can al
 
 ## WalletConnect Explorer
 
-[WalletConnect Explorer](https://explorer.walletconnect.com) allows users to discover and WalletConnect-enabled dapps and wallets.
+[WalletConnect Explorer](https://explorer.walletconnect.com) allows users to discover WalletConnect-enabled dapps and wallets.
 For developers, [Explorer API](/cloud/explorer) currently offers the following functionality:
 
 - **Listings** : Allows for fetching of wallets and dApps listed in the WalletConnect Cloud Explorer.


### PR DESCRIPTION
Changed "WalletConnect Explorer allows users to discover _and_ WalletConnect-enabled dapps and wallets." to "WalletConnect Explorer allows users to discover WalletConnect-enabled dapps and wallets." for better intelligibility.