### PR TITLE
fix: update Solana CAIP-2 chainId reference

### DIFF
--- a/docs/web3modal/v2/_partials/options/chains.mdx
+++ b/docs/web3modal/v2/_partials/options/chains.mdx
@@ -3,7 +3,7 @@ Array of [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-
 ```ts
 chains: [
   'eip155:1',
-  'solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ',
+  'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
   'cosmos:cosmoshub-4',
   'polkadot:91b171bb158e2d3848fa23a9f1c25182'
 ]


### PR DESCRIPTION
## Context

* The CAIP-2 standard for Solana was fixed after-the-fact to contain the correct genesis hashes for each chain: https://github.com/ChainAgnostic/namespaces/blob/main/solana%2Fcaip2.md#test-cases
* Our documentation and sample code references need to be adjusted to the canonical hashes/chainIds.