### PR TITLE
chore: removed alpha tag from analytics

### DIFF
--- a/docs/web3modal/react-native/options.mdx
+++ b/docs/web3modal/react-native/options.mdx
@@ -177,9 +177,6 @@ createWeb3Modal({
 
 ## enableAnalytics
 
-:::caution
-Analytics is currently in alpha.
-:::
 Enable analytics to get more insights on your users activity within your [WalletConnect Cloud's dashboard](https://cloud.walletconnect.com)
 
 ```ts


### PR DESCRIPTION
### Summary
Removed alpha tag from `enableAnalytics` prop in React Native