### PR TITLE
fix: improve Push Server docs

### DIFF
--- a/docs/advanced/push-server.md
+++ b/docs/advanced/push-server.md
@@ -8,7 +8,7 @@ Several options exist for setting up the Push Server:
 2. Self-host the [Push Server](https://github.com/WalletConnect/push-server)
 3. Write your own implementation using the [spec](https://specs.walletconnect.com/2.0/specs/servers/push/spec)
 
-It is recommended that you use our hosted platform for simplicity and ease of integration. Typically you only need to self-host if you have concerns about our hosted platform having access to your FCM or APNs server credentials, such as for regulatory reasons. If you want to self-host or implement against the spec, please reach out to devrel@walletconnect.com for assistance.
+It is recommended that you use WalletConnect Cloud for simplicity and ease of integration. Typically you only need to self-host if you have concerns about our hosted platform having access to your FCM or APNs server credentials, such as for regulatory reasons. If you want to self-host or implement against the spec, please reach out to devrel@walletconnect.com for assistance.
 
 ## Setup in WalletConnect Cloud
 

--- a/docs/advanced/push-server.md
+++ b/docs/advanced/push-server.md
@@ -4,13 +4,13 @@ The Push Server sends WalletConnect protocol activity using FCM or APNs to users
 
 Several options exist for setting up the Push Server:
 
-1. Using our [hosted](#hosted-platform-recommended) solution (recommended)
+1. Using [WalletConnect Cloud](#hosted-platform-recommended) (recommended)
 2. Self-host the [Push Server](https://github.com/WalletConnect/push-server)
 3. Write your own implementation using the [spec](https://specs.walletconnect.com/2.0/specs/servers/push/spec)
 
 It is recommended that you use our hosted platform for simplicity and ease of integration. Typically you only need to self-host if you have concerns about our hosted platform having access to your FCM or APNs server credentials, such as for regulatory reasons. If you want to self-host or implement against the spec, please reach out to devrel@walletconnect.com for assistance.
 
-## Hosted platform (recommended)
+## WalletConnect Cloud (recommended)
 
 1. Create a Project in the Cloud App. Go to [WalletConnect Cloud](https://cloud.walletconnect.com/) and sign up for an account.
 

--- a/docs/advanced/push-server.md
+++ b/docs/advanced/push-server.md
@@ -1,18 +1,16 @@
 # Push Server
 
-The Push Server is a push server for the WalletConnect v2 Protocol. It allows clients to send push notifications to their users. The Push Server can be used with our [Notify API](../web3wallet/notify/introduction.mdx) and [Web3Wallet SDK](../web3wallet/about.mdx).
+The Push Server sends WalletConnect protocol activity using FCM or APNs to users. The Push Server can be used with our [Notify API](../web3wallet/notify/introduction.mdx) and [Web3Wallet SDK](../web3wallet/about.mdx).
 
-## Options for Receiving Push Notifications
+Several options exist for setting up the Push Server:
 
-1. Use the [hosted](#hosted-platform-recommended) platform (recommended).
-2. Self-Host our [server](https://github.com/WalletConnect/echo-server).
-3. Write your own implementation using the [spec](https://specs.walletconnect.com/2.0/specs/servers/push/spec).
+1. Using our [hosted](#hosted-platform-recommended) solution (recommended)
+2. Self-host the [Push Server](https://github.com/WalletConnect/push-server)
+3. Write your own implementation using the [spec](https://specs.walletconnect.com/2.0/specs/servers/push/spec)
 
-:::note
-For inquiries about self-hosting, please send an email to devrel@walletconnect.com.
-:::
+It is recommended that you use our hosted platform for simplicity and ease of integration. Typically you only need to self-host if you have concerns about our hosted platform having access to your FCM or APNs server credentials, such as for regulatory reasons. If you want to self-host or implement against the spec, please reach out to devrel@walletconnect.com for assistance.
 
-## Hosted Platform (recommended)
+## Hosted platform (recommended)
 
 1. Create a Project in the Cloud App. Go to [WalletConnect Cloud](https://cloud.walletconnect.com/) and sign up for an account.
 

--- a/docs/advanced/push-server.md
+++ b/docs/advanced/push-server.md
@@ -4,13 +4,13 @@ The Push Server sends WalletConnect protocol activity using FCM or APNs to users
 
 Several options exist for setting up the Push Server:
 
-1. Using [WalletConnect Cloud](#hosted-platform-recommended) (recommended)
+1. Using [WalletConnect Cloud](#setup-in-walletconnect-cloud) (recommended)
 2. Self-host the [Push Server](https://github.com/WalletConnect/push-server)
 3. Write your own implementation using the [spec](https://specs.walletconnect.com/2.0/specs/servers/push/spec)
 
 It is recommended that you use our hosted platform for simplicity and ease of integration. Typically you only need to self-host if you have concerns about our hosted platform having access to your FCM or APNs server credentials, such as for regulatory reasons. If you want to self-host or implement against the spec, please reach out to devrel@walletconnect.com for assistance.
 
-## WalletConnect Cloud (recommended)
+## Setup in WalletConnect Cloud
 
 1. Create a Project in the Cloud App. Go to [WalletConnect Cloud](https://cloud.walletconnect.com/) and sign up for an account.
 

--- a/docs/advanced/push-server.md
+++ b/docs/advanced/push-server.md
@@ -18,20 +18,22 @@ It is recommended that you use WalletConnect Cloud for simplicity and ease of in
 
 ![create-push-url](/assets/create-push-url.png)
 
-3. From the same settings tab, you will see the FCM and the APNS settings becomes available to setup. Add your [FCM](#firebase-cloud-messaging-fcm) and/or [APNS](#apple-push-notifications-apns) details.
+3. From the same settings tab, you will see the FCM and the APNS settings becomes available to setup. Add your [FCM](#firebase-cloud-messaging-fcm) and/or [APNs](#apple-push-notifications-apns) details.
 
 ![fmc-and-apns-details-form](/assets/apns-fmc-details.png)
 
 ### Firebase Cloud Messaging (FCM)
 
-Google's FCM allows you to use send notifications to both Android and Apple devices. At this time, we only support the API. Please refer to their docs on set up.
+Google's FCM allows you to use send notifications to both Android and Apple devices. At this time, we only support Android devices via FCM.
+
+Currently we only support Cloud Messaging API (Legacy) but are currently working on supporting Firebase Cloud Messaging API (V1) very soon.
 
 - Enable Legacy Cloud Messaging API in the Firebase Project Settings
   ![legacy-fcm-cloud-messaging](/assets/legacy-fcm-cloud-messaging-api.png)
 - [Set up Android](https://firebase.google.com/docs/cloud-messaging/android/client)
 - [Set up Apple](https://firebase.google.com/docs/cloud-messaging/ios/client)
 
-### Apple Push Notifications (APNS)
+### Apple Push Notifications (APNs)
 
 Apple recommends using a Token-Based Connection for APNS over a Certificate-Based connection. Please refer to their documentation for instructions on obtaining either.
 

--- a/docs/web3wallet/push-notifications.mdx
+++ b/docs/web3wallet/push-notifications.mdx
@@ -3,9 +3,15 @@ import PlatformTabItem from '../components/PlatformTabItem'
 
 # Push Notifications
 
-The WalletConnect Web3Wallet SDK provides the functionality for wallets to receive push notifications through Firebase Cloud Messaging (FCM) and Apple Push Notification Service (APNS) via the Push Server. This feature ensures that wallets are promptly notified of incoming signature requests. Each push notification contains the encrypted details of the signature request. Upon receiving the notification, it can be decrypted and presented to the developer, allowing for customization of the message according to their requirements.
+The WalletConnect Web3Wallet SDK provides the functionality for wallets to receive push notifications through Firebase Cloud Messaging (FCM) and Apple Push Notification Service (APNs) via the Push Server. This feature ensures that wallets are promptly notified of incoming signature requests. Each push notification contains the encrypted details of the signature request. Upon receiving the notification, it can be decrypted and presented to the developer, allowing for customization of the message according to their requirements.
 
-## Setup
+## Server setup
+
+For the push notifications to be forwarded to FCM or APNs, the [Push Server](../advanced/push-server) will need to be configured with your FCM or APNs server API credentials.
+
+## App setup
+
+### Register the device token
 
 To enable a device for push notifications, it's essential to register the device token using `Web3Wallet.registerDeviceToken`. This token can be obtained from either FCM or APNS, depending on the platform used.
 
@@ -89,7 +95,7 @@ messaging().onTokenRefresh(async token => {
 </PlatformTabItem>
 </PlatformTabs>
 
-## Usage
+### Receiving push notifications
 
 After the device token is registered, the next step involves setting up the notification service specific to the platform being used. This service will decrypt the incoming requests and forward them to the developer for further processing and integration.
 


### PR DESCRIPTION
In regards to [this conversation](https://github.com/WalletConnect/walletconnect-monorepo/issues/4465#) we don't actually tell the developer following the Web3Wallet guide how to setup Push Server. Adding the relevant links for that, as well as streamlining the Push Server docs.