### PR TITLE
Fix: Added groupId to siwe tabs

### DIFF
--- a/docs/appkit/javascript/core/siwe.mdx
+++ b/docs/appkit/javascript/core/siwe.mdx
@@ -19,7 +19,7 @@ WalletConnect uses permissions expressed as ReCaps to enable a One-Click Authent
 
 ## Installation
 
-<Tabs>
+<Tabs groupId="version">
 <TabItem value="one-click-auth" label="One-Click Auth">
 
 ```bash npm2yarn

--- a/docs/appkit/next/core/siwe.mdx
+++ b/docs/appkit/next/core/siwe.mdx
@@ -25,8 +25,8 @@ It is designed from the ground up to support Next.js and Serverless. We can use 
 
 ## Installation
 
-<Tabs>
-<TabItem value="oca" label="One-Click Auth">
+<Tabs groupId="version">
+<TabItem value="one-click-auth" label="One-Click Auth">
 
 ```bash npm2yarn
 npm i @web3modal/siwe next-auth
@@ -50,8 +50,8 @@ npm i @web3modal/siwe siwe next-auth
 
 ## Configure your SIWE Client
 
-<Tabs>
-<TabItem value="oca" label="One-Click Auth">
+<Tabs groupId="version">
+<TabItem value="one-click-auth" label="One-Click Auth">
 
 ```ts
 import { getCsrfToken, signIn, signOut, getSession } from 'next-auth/react'
@@ -220,8 +220,8 @@ Add `NEXTAUTH_SECRET` as an environment variable, it will be used to encrypt and
 
 Create your API route at `app/api/auth/[...nextauth]/route.ts`.
 
-<Tabs>
-<TabItem value="oca" label="One-Click Auth">
+<Tabs groupId="version">
+<TabItem value="one-click-auth" label="One-Click Auth">
 
 ```ts
 import NextAuth from 'next-auth'
@@ -412,19 +412,20 @@ const handler = NextAuth(authOptions)
 export { handler as GET, handler as POST }
 ```
 
-## Initialize Web3Modal with your `siweConfig`.
-
-```js
-createWeb3Modal({
-  siweConfig,
-  ...
-})
-```
 
 </TabItem>
 </Tabs>
 
 <Button name="Learn More" url="https://next-auth.js.org/" />
+
+## Initialize Web3Modal with your `siweConfig`.
+
+```js
+createWeb3Modal({
+  //..
+  siweConfig
+})
+```
 
 ### SIWE Config reference
 

--- a/docs/appkit/react/core/siwe.mdx
+++ b/docs/appkit/react/core/siwe.mdx
@@ -22,7 +22,7 @@ WalletConnect uses permissions expressed as ReCaps to enable a One-Click Authent
 
 ## Installation
 
-<Tabs>
+<Tabs groupId="version">
 <TabItem value="one-click-auth" label="One-Click Auth">
 
 ```bash npm2yarn

--- a/docs/appkit/shared/siwe/code.mdx
+++ b/docs/appkit/shared/siwe/code.mdx
@@ -1,7 +1,7 @@
 import Tabs from '@theme/Tabs'
 import TabItem from '@theme/TabItem'
 
-<Tabs>
+<Tabs groupId="version">
 <TabItem value="one-click-auth" label="One-Click Auth">
 
 ```ts

--- a/docs/appkit/shared/siwe/parameters.mdx
+++ b/docs/appkit/shared/siwe/parameters.mdx
@@ -1,10 +1,10 @@
 import Tabs from '@theme/Tabs'
 import TabItem from '@theme/TabItem'
 
-<Tabs>
+<Tabs groupId="version">
 <TabItem value="one-click-auth" label="One-Click Auth">
 
-### getMessageParams `() => Promise<{ domain: string, uri: string, chains: number[], statement: string }>`
+#### getMessageParams `() => Promise<{ domain: string, uri: string, chains: number[], statement: string }>`
 
 Parameters to create the SIWE message internally.
 

--- a/docs/appkit/vue/core/siwe.mdx
+++ b/docs/appkit/vue/core/siwe.mdx
@@ -19,7 +19,7 @@ WalletConnect uses permissions expressed as ReCaps to enable a One-Click Authent
 
 ## Installation
 
-<Tabs>
+<Tabs groupId="version">
 <TabItem value="one-click-auth" label="One-Click Auth">
 
 ```bash npm2yarn


### PR DESCRIPTION
### Summary
Added groupId to SIWE tabs so when the user press "One-Click Auth" or "Legacy" it changes in all tabs

### Screnshots
Before:

https://github.com/WalletConnect/walletconnect-docs/assets/25931366/d076bb91-e1d3-451a-a399-f007093933ec

After:

https://github.com/WalletConnect/walletconnect-docs/assets/25931366/15c76b67-9e7a-450f-baa0-73d9a3198b27

