### PR TITLE
chore: added extra step for RN w3w expo

### DIFF
--- a/docs/walletkit/react-native/installation.mdx
+++ b/docs/walletkit/react-native/installation.mdx
@@ -12,6 +12,15 @@ Additionally add these extra packages to help with async storage, polyfills and 
 npm install @react-native-async-storage/async-storage @react-native-community/netinfo react-native-get-random-values fast-text-encoding @ethersproject/shims ethers@5.7.2 @json-rpc-tools/utils
 ```
 
+<details>
+<summary>Additional setup for Expo</summary>
+<div>
+```
+npx expo install expo-application
+```
+</div>
+</details>
+
 For those using Typescript, we recommend adding these dev dependencies:
 
 ```bash npm2yarn


### PR DESCRIPTION
### Summary
Added missing package installation for Expo projects that want to use Web3Wallet React Native

related: https://github.com/WalletConnect/walletconnect-monorepo/issues/4586