### PR TITLE
added: /vue to the path for createWeb3Modal.

### DIFF
--- a/docs/appkit/vue/wagmi/about/implementation.mdx
+++ b/docs/appkit/vue/wagmi/about/implementation.mdx
@@ -9,7 +9,7 @@ In your `App.vue` file set up the following configuration
 
 ```html
 <script setup>
-  import { createWeb3Modal, defaultWagmiConfig } from '@web3modal/wagmi'
+  import { createWeb3Modal, defaultWagmiConfig } from '@web3modal/wagmi/vue'
 
   import { mainnet, arbitrum } from 'viem/chains'
   import { reconnect } from '@wagmi/core'


### PR DESCRIPTION
Title: Fix usage of composables in web3modal

Description:
I encountered an issue when using the composables in the web3modal library. Specifically, I was getting the following error message:

Please call "createWeb3Modal" before using "useWeb3Modal"
To address this, I made a fix that ensures createWeb3Modal is called before useWeb3Modal is used. This should resolve the initialization issue and make the composables work as expected.

I was able to fix the problem by adding the /vue to the end of the path of the following import. This is what it said to do in the documentation:
import { createWeb3Modal, defaultWagmiConfig } from "@web3modal/wagmi

I changed it to:
import { createWeb3Modal, defaultWagmiConfig } from "@web3modal/wagmi/vue"

Related Issue/Comment:
The clue to solving this problem was found in this discussion: [GitHub Issue #1549 - Comment](https://github.com/WalletConnect/web3modal/issues/1549#issuecomment-2027149767)

Time Spent:
It took me 3 days to figure out what I was doing wrong and to implement this fix.

Additional Context:
Please review the changes and let me know if there are any adjustments or improvements needed. I believe this fix will help others who might encounter the same issue.

Thank you!
