### PR TITLE
Replacing example containing non-existent parameter

### DIFF
--- a/docs/appkit/react-native/wagmi/about/implementation.mdx
+++ b/docs/appkit/react-native/wagmi/about/implementation.mdx
@@ -43,7 +43,7 @@ const wagmiConfig = defaultWagmiConfig({ chains, projectId, metadata })
 createWeb3Modal({
   projectId,
   wagmiConfig,
-  defaultChain: mainnet,
+  defaultChain: mainnet, // Optional
   enableAnalytics: true // Optional - defaults to your Cloud configuration
 })
 

--- a/docs/appkit/react-native/wagmi/about/implementation.mdx
+++ b/docs/appkit/react-native/wagmi/about/implementation.mdx
@@ -42,8 +42,8 @@ const wagmiConfig = defaultWagmiConfig({ chains, projectId, metadata })
 // 3. Create modal
 createWeb3Modal({
   projectId,
-  chains,
   wagmiConfig,
+  defaultChain: mainnet,
   enableAnalytics: true // Optional - defaults to your Cloud configuration
 })
 


### PR DESCRIPTION
Replacing the `chains` parameter with the `defaultChain` during the Web3Modal initialisation.

The chains parameter does not exist anymore.