### PR TITLE
Remove WalletConnectModal from docs.

### DIFF
--- a/docs/readme.mdx
+++ b/docs/readme.mdx
@@ -53,12 +53,6 @@ Utility tools for advanced usage with WalletConnect
   type="large"
   items={[
     {
-      name: 'WalletConnectModal',
-      icon: wcmLogo,
-      href: '/advanced/walletconnectmodal/about',
-      description: 'A no-frills modal for wallet connections'
-    },
-    {
       name: 'Ethereum Provider',
       icon: ethereumProviderLogo,
       href: '/advanced/providers/ethereum',

--- a/sidebars.js
+++ b/sidebars.js
@@ -81,19 +81,6 @@ const advanced = {
     },
     {
       type: 'category',
-      label: 'WalletConnectModal',
-      collapsed: true,
-      collapsible: true,
-      items: [
-        'advanced/walletconnectmodal/about',
-        'advanced/walletconnectmodal/usage',
-        'advanced/walletconnectmodal/options',
-        'advanced/walletconnectmodal/theming',
-        'advanced/walletconnectmodal/resources'
-      ]
-    },
-    {
-      type: 'category',
       label: 'APIs',
       collapsed: true,
       collapsible: true,

--- a/sidebars.js
+++ b/sidebars.js
@@ -150,6 +150,32 @@ const welcome = {
 /** @type {import('@docusaurus/plugin-content-docs').SidebarsConfig} */
 
 module.exports = {
+  WCM:[
+    {
+      type: 'doc',
+      label: 'Home',
+      className: 'kill',
+      id: 'readme'
+    },
+    {
+      type: 'link',
+      label: 'Welcome',
+      href: '/'
+    },
+    {
+      type: 'category',
+      label: 'WalletConnectModal',
+      collapsible: false,
+      className: 'menu_outer_list',
+      items: [
+        'advanced/walletconnectmodal/about',
+        'advanced/walletconnectmodal/usage',
+        'advanced/walletconnectmodal/options',
+        'advanced/walletconnectmodal/theming',
+        'advanced/walletconnectmodal/resources'
+      ]
+    },
+  ],
   mainSidebar: [
     {
       type: 'doc',


### PR DESCRIPTION
- Remove WalletConnectModal from the sidebar and the main view
- Links to WalletConnectModal are still available but isolated
![image](https://github.com/WalletConnect/walletconnect-docs/assets/66949816/c145160a-74b2-4431-89c5-5c195bb6910d)
