### PR TITLE
kotlin: new CoreClient initialize method

### DIFF
--- a/docs/advanced/walletconnectmodal/usage.mdx
+++ b/docs/advanced/walletconnectmodal/usage.mdx
@@ -119,8 +119,6 @@ or you can change them later by calling `WalletConnectModal.set(sessionParams: S
 ```kotlin
 val connectionType = ConnectionType.AUTOMATIC or ConnectionType.MANUAL
 val projectId = "" // Get Project ID at https://cloud.walletconnect.com/
-val relayUrl = "relay.walletconnect.com"
-val serverUrl = "wss://$relayUrl?projectId=${projectId}"
 val appMetaData = Core.Model.AppMetaData(
     name = "Kotlin.WalletConnectModal",
     description = "Kotlin WalletConnectModal Implementation",
@@ -129,7 +127,7 @@ val appMetaData = Core.Model.AppMetaData(
     redirect = "kotlin-modal://request"
 )
 
-CoreClient.initialize(relayServerUrl = serverUrl, connectionType = connectionType, application = this, metaData = appMetaData)
+CoreClient.initialize(projectId = projectId, connectionType = connectionType, application = this, metaData = appMetaData)
 
 WalletConnectModal.initialize(
     init = Modal.Params.Init(CoreClient),

--- a/docs/api/core/pairing.mdx
+++ b/docs/api/core/pairing.mdx
@@ -81,13 +81,11 @@ Before using any of the WalletConnect Kotlin SDKs, it is necessary to initialize
 
 ```kotlin
 val projectId = "" //Get Project ID at https://cloud.walletconnect.com/
-val relayUrl = "relay.walletconnect.com"
-val serverUrl = "wss://$relayUrl?projectId=${projectId}"
 val connectionType = ConnectionType.AUTOMATIC or ConnectionType.MANUAL
 val application = //Android Application level class
 [Optional] val optionalRelay: RelayConnectionInterface? = /*implement interface*/
 
-CoreClient.initialize(relayServerUrl = serverUrl, connectionType = connectionType, application = application, relay = optionalRelay)
+CoreClient.initialize(projectId = projectId, connectionType = connectionType, application = application, relay = optionalRelay)
 ```
 
 #### Using your own Relay instance
@@ -98,7 +96,7 @@ The CoreClient offers the ability to use a custom Relay client. Just creating an
 ...
 val optionalRelay: RelayConnectionInterface = /*implement interface*/
 
-CoreClient.initialize(relayServerUrl = serverUrl, connectionType = connectionType, application = application, relay = optionalRelay)
+CoreClient.initialize(projectId = projectId, connectionType = connectionType, application = application, relay = optionalRelay)
 ```
 
 </PlatformTabItem>

--- a/docs/api/core/relay.mdx
+++ b/docs/api/core/relay.mdx
@@ -92,7 +92,7 @@ Automatic connection type enables SDK to control web socket connection internall
 Manual connection type enables developers to control web socket connection.
 
 ```kotlin
-CoreClient.initialize(relayServerUrl = serverUrl, connectionType = ConnectionType.MANUAL, application = application)
+CoreClient.initialize(projectId = projectId, connectionType = ConnectionType.MANUAL, application = application)
 
 CoreClient.Relay.connect() { error -> /*Error when wrong connection type is in use*/}
 

--- a/docs/api/notify/usage.mdx
+++ b/docs/api/notify/usage.mdx
@@ -513,8 +513,6 @@ The Notify client is responsible for creating and maintaining subscriptions. To 
 
 ```kotlin
 val projectId = "" // Get Project ID at https://cloud.walletconnect.com/
-val relayUrl = "relay.walletconnect.com"
-val serverUrl = "wss://$relayUrl?projectId=$projectId"
 val connectionType = ConnectionType.AUTOMATIC or ConnectionType.MANUAL
 val appMetaData = Core.Model.AppMetaData(
     name = "Wallet Name",
@@ -524,7 +522,7 @@ val appMetaData = Core.Model.AppMetaData(
     redirect = "kotlin-wallet-wc:/request" // Custom Redirect URI
 )
 
-CoreClient.initialize(relayServerUrl = serverUrl, connectionType = connectionType, application = this, metaData = appMetaData)
+CoreClient.initialize(projectId = projectId, connectionType = connectionType, application = this, metaData = appMetaData)
 
 val init = Notify.Params.Init(CoreClient)
 

--- a/docs/api/sign/dapp-usage.md
+++ b/docs/api/sign/dapp-usage.md
@@ -396,8 +396,6 @@ Above method will extend a user's session to a week.
 
 ```kotlin
 val projectId = "" // Get Project ID at https://cloud.walletconnect.com/
-val relayUrl = "relay.walletconnect.com"
-val serverUrl = "wss://$relayUrl?projectId=$projectId"
 val connectionType = ConnectionType.AUTOMATIC or ConnectionType.MANUAL
 val appMetaData = Core.Model.AppMetaData(
     name = "Dapp Name",
@@ -407,7 +405,7 @@ val appMetaData = Core.Model.AppMetaData(
     redirect = "kotlin-dapp-wc:/request" // Custom Redirect URI
 )
 
-CoreClient.initialize(relayServerUrl = serverUrl, connectionType = connectionType, application = this, metaData = appMetaData)
+CoreClient.initialize(projectId = projectId, connectionType = connectionType, application = this, metaData = appMetaData)
 
 val init = Sign.Params.Init(core = CoreClient)
 

--- a/docs/api/sign/wallet-usage.md
+++ b/docs/api/sign/wallet-usage.md
@@ -692,8 +692,6 @@ try await Sign.instance.rejectSession(requestId: requestId)
 
 ```kotlin
 val projectId = "" // Get Project ID at https://cloud.walletconnect.com/
-val relayUrl = "relay.walletconnect.com"
-val serverUrl = "wss://$relayUrl?projectId=$projectId"
 val connectionType = ConnectionType.AUTOMATIC or ConnectionType.MANUAL
 val appMetaData = Core.Model.AppMetaData(
     name = "Wallet Name",
@@ -703,7 +701,7 @@ val appMetaData = Core.Model.AppMetaData(
     redirect = "kotlin-wallet-wc:/request" // Custom Redirect URI
 )
 
-CoreClient.initialize(relayServerUrl = serverUrl, connectionType = connectionType, application = this, metaData = appMetaData)
+CoreClient.initialize(projectId = projectId, connectionType = connectionType, application = this, metaData = appMetaData)
 
 val init = Sign.Params.Init(core = CoreClient)
 

--- a/docs/appkit/android/core/usage.mdx
+++ b/docs/appkit/android/core/usage.mdx
@@ -12,8 +12,6 @@ import TabItem from '@theme/TabItem'
 ```kotlin
 val connectionType = ConnectionType.AUTOMATIC or ConnectionType.MANUAL
 val projectId = "" // Get Project ID at https://cloud.walletconnect.com/
-val relayUrl = "relay.walletconnect.com"
-val serverUrl = "wss://$relayUrl?projectId=${projectId}"
 val appMetaData = Core.Model.AppMetaData(
     name = "Kotlin.Web3Modal",
     description = "Kotlin Web3Modal Implementation",
@@ -22,7 +20,7 @@ val appMetaData = Core.Model.AppMetaData(
     redirect = "kotlin-web3modal://request"
 )
 
-CoreClient.initialize(relayServerUrl = serverUrl, connectionType = connectionType, application = this, metaData = appMetaData)
+CoreClient.initialize(projectId = projectId, connectionType = connectionType, application = this, metaData = appMetaData)
 
 Web3Modal.initialize(
     init = Modal.Params.Init(CoreClient),

--- a/docs/walletkit/android/mobile-linking.mdx
+++ b/docs/walletkit/android/mobile-linking.mdx
@@ -111,7 +111,7 @@ val appMetaData = Core.Model.AppMetaData(
     redirect = redirect
 )
 
-CoreClient.initialize(relayServerUrl = serverUrl, connectionType = connectionType, application = application, metaData = appMetaData)
+CoreClient.initialize(projectId = projectId, connectionType = connectionType, application = application, metaData = appMetaData)
 
 val init = Wallet.Params.Init(coreClient = CoreClient)
 Web3Wallet.initialize(init)
@@ -164,7 +164,7 @@ val appMetaData = Core.Model.AppMetaData(
     redirect = redirect
 )
 
-CoreClient.initialize(relayServerUrl = serverUrl, connectionType = connectionType, application = application, metaData = appMetaData)
+CoreClient.initialize(projectId = projectId, connectionType = connectionType, application = application, metaData = appMetaData)
 
 val init = Sign.Params.Init(core = CoreClient)
 SignClient.initialize(init)

--- a/docs/walletkit/android/notifications/notify/usage.mdx
+++ b/docs/walletkit/android/notifications/notify/usage.mdx
@@ -43,7 +43,6 @@ To initialize the Notify client, create a `Notify.Params.Init` object in the And
 
 ```kotlin
 val projectId = PROJECT_ID
-val serverUrl = "wss://relay.walletconnect.com?projectId=$projectId"
 val appMetaData = Core.Model.AppMetaData(
     name = /* The name of your project as a String */,
     description = /* A description of your project as a String */,
@@ -52,7 +51,7 @@ val appMetaData = Core.Model.AppMetaData(
     redirect = /* A redirect URI used by Dapps to deeplink back to your wallet. This is a String value  */
 )
 
-CoreClient.initialize(relayServerUrl = serverUrl, connectionType = ConnectionType.AUTOMATIC, application = this, metaData = appMetaData)
+CoreClient.initialize(projectId = projectId, connectionType = ConnectionType.AUTOMATIC, application = this, metaData = appMetaData)
 
 Notify.initialize(init = Notify.Params.Init(core = CoreClient) { error: Notify.Model.Error ->
     // Error will be thrown if there's an issue during initialization

--- a/docs/walletkit/android/usage.mdx
+++ b/docs/walletkit/android/usage.mdx
@@ -41,8 +41,6 @@ To check the full list of platform specific instructions for your preferred plat
 
 ```kotlin
 val projectId = "" // Get Project ID at https://cloud.walletconnect.com/
-val relayUrl = "relay.walletconnect.com"
-val serverUrl = "wss://$relayUrl?projectId=$projectId"
 val connectionType = ConnectionType.AUTOMATIC or ConnectionType.MANUAL
 val telemetryEnabled: Boolean = true
 val appMetaData = Core.Model.AppMetaData(
@@ -53,7 +51,7 @@ val appMetaData = Core.Model.AppMetaData(
     redirect = "kotlin-wallet-wc:/request" // Custom Redirect URI
 )
 
-CoreClient.initialize(relayServerUrl = serverUrl, connectionType = connectionType, application = this, metaData = appMetaData, telemetryEnabled = telemetryEnabled)
+CoreClient.initialize(projectId = projectId, connectionType = connectionType, application = this, metaData = appMetaData, telemetryEnabled = telemetryEnabled)
 
 val initParams = Wallet.Params.Init(core = CoreClient)
 


### PR DESCRIPTION
This PR introduces a simplified CoreClient initialize method where developers would have to pass only projectId without the Relay URL. The Relay URL is built internally.

For backward compatibility, the old method is not removed.