### PR TITLE
chore: added cloud note for react native universal wallets

### DIFF
--- a/docs/appkit/react-native/core/installation.mdx
+++ b/docs/appkit/react-native/core/installation.mdx
@@ -300,8 +300,8 @@ npx install-expo-modules@latest
 
 2. Install Coinbase SDK
 
-```bash npm2yarn
-npm install @coinbase/wallet-mobile-sdk react-native-mmkv
+```
+yarn add @coinbase/wallet-mobile-sdk react-native-mmkv
 ```
 
 3. Install our custom connector
@@ -309,20 +309,20 @@ npm install @coinbase/wallet-mobile-sdk react-native-mmkv
 <PlatformTabs groupId="eth-lib" activeOptions={["wagmi", "ethers", "ethers5"]}>
 
 <PlatformTabItem value="wagmi">
-```bash npm2yarn
-npm install @web3modal/coinbase-wagmi-react-native
+```
+yarn add @web3modal/coinbase-wagmi-react-native
 ```
 </PlatformTabItem>
 
 <PlatformTabItem value="ethers">
-```bash npm2yarn
-npm install @web3modal/coinbase-ethers-react-native
+```
+yarn add @web3modal/coinbase-ethers-react-native
 ```
 </PlatformTabItem>
 
 <PlatformTabItem value="ethers5">
-```bash npm2yarn
-npm install @web3modal/coinbase-ethers-react-native
+```
+yarn add @web3modal/coinbase-ethers-react-native
 ```
 </PlatformTabItem>
 

--- a/docs/appkit/react-native/ethers/about/installation.mdx
+++ b/docs/appkit/react-native/ethers/about/installation.mdx
@@ -1,11 +1,11 @@
-```bash npm2yarn
-npm install @web3modal/ethers-react-native ethers
+```
+yarn add @web3modal/ethers-react-native ethers
 ```
 
 Additionally add these extra packages to help with async storage, polyfills, and SVG's.
 
-```bash npm2yarn
-npm install @react-native-async-storage/async-storage react-native-get-random-values react-native-svg react-native-modal @react-native-community/netinfo @walletconnect/react-native-compat
+```
+yarn add @react-native-async-storage/async-storage react-native-get-random-values react-native-svg react-native-modal @react-native-community/netinfo @walletconnect/react-native-compat
 ```
 
 On iOS, use CocoaPods to add the native modules to your project:

--- a/docs/appkit/react-native/ethers/email.mdx
+++ b/docs/appkit/react-native/ethers/email.mdx
@@ -3,8 +3,8 @@ import TabItem from '@theme/TabItem'
 
 ### Install packages
 
-```bash npm2yarn
-npm install react-native-webview @web3modal/email-ethers-react-native
+```
+yarn add react-native-webview @web3modal/email-ethers-react-native
 ```
 
 On iOS, use CocoaPods to add the native modules to your project:

--- a/docs/appkit/react-native/ethers5/about/installation.mdx
+++ b/docs/appkit/react-native/ethers5/about/installation.mdx
@@ -1,11 +1,11 @@
-```bash npm2yarn
-npm install @web3modal/ethers5-react-native ethers@5.7.2
+```
+yarn add @web3modal/ethers5-react-native ethers@5.7.2
 ```
 
 Additionally add these extra packages to help with async storage, polyfills, and SVG's.
 
-```bash npm2yarn
-npm install @ethersproject/shims@5.7.0 @react-native-async-storage/async-storage react-native-get-random-values react-native-svg react-native-modal @react-native-community/netinfo @walletconnect/react-native-compat
+```
+yarn add @ethersproject/shims@5.7.0 @react-native-async-storage/async-storage react-native-get-random-values react-native-svg react-native-modal @react-native-community/netinfo @walletconnect/react-native-compat
 ```
 
 On iOS, use CocoaPods to add the native modules to your project:

--- a/docs/appkit/react-native/onboarding/email.mdx
+++ b/docs/appkit/react-native/onboarding/email.mdx
@@ -18,11 +18,24 @@ Due to Safari’s strict third-party cookie policies, the SDK is not preserving 
 
 <PlatformTabs groupId="eth-lib" activeOptions={["wagmi", "ethers"]}>
 
+
 <PlatformTabItem value="wagmi">
+   ### Update your Cloud settings
+   1. Go to your [Cloud](https://cloud.walletconnect.com) project
+   2. Open Dashboard and scroll down to Mobile Application IDs menu
+   3. Add your iOS Bundle ID and your Android Package Name
+   * Changes might take some minutes to impact
+
    <WagmiImplementation />
 </PlatformTabItem>
 
 <PlatformTabItem value="ethers">
+   ### Update your Cloud settings
+   1. Go to your [Cloud](https://cloud.walletconnect.com) project
+   2. Open Dashboard and scroll down to Mobile Application IDs menu
+   3. Add your iOS Bundle ID and your Android Package Name
+   * Changes might take some minutes to impact
+   
    <EthersImplementation />
 </PlatformTabItem>
 

--- a/docs/appkit/react-native/onboarding/email.mdx
+++ b/docs/appkit/react-native/onboarding/email.mdx
@@ -23,7 +23,7 @@ Due to Safari’s strict third-party cookie policies, the SDK is not preserving 
    ### Update your Cloud settings
    1. Go to your [Cloud](https://cloud.walletconnect.com) project
    2. Open Dashboard and scroll down to Mobile Application IDs menu
-   3. Add your iOS Bundle ID and your Android Package Name
+   3. Add your iOS Bundle ID and/or your Android Package Name
    * Changes might take some minutes to impact
 
    <WagmiImplementation />

--- a/docs/appkit/react-native/onboarding/email.mdx
+++ b/docs/appkit/react-native/onboarding/email.mdx
@@ -33,7 +33,7 @@ Due to Safari’s strict third-party cookie policies, the SDK is not preserving 
    ### Update your Cloud settings
    1. Go to your [Cloud](https://cloud.walletconnect.com) project
    2. Open Dashboard and scroll down to Mobile Application IDs menu
-   3. Add your iOS Bundle ID and your Android Package Name
+   3. Add your iOS Bundle ID and/or your Android Package Name
    * Changes might take some minutes to impact
    
    <EthersImplementation />

--- a/docs/appkit/react-native/wagmi/about/installation.mdx
+++ b/docs/appkit/react-native/wagmi/about/installation.mdx
@@ -1,11 +1,11 @@
-```bash npm2yarn
-npm install @web3modal/wagmi-react-native wagmi viem @tanstack/react-query
+```
+yarn add @web3modal/wagmi-react-native wagmi viem @tanstack/react-query
 ```
 
 Additionally add these extra packages to help with async storage, polyfills, and SVG's.
 
-```bash npm2yarn
-npm install @react-native-async-storage/async-storage react-native-get-random-values react-native-svg react-native-modal @react-native-community/netinfo @walletconnect/react-native-compat
+```
+yarn add @react-native-async-storage/async-storage react-native-get-random-values react-native-svg react-native-modal @react-native-community/netinfo @walletconnect/react-native-compat
 ```
 
 On iOS, use CocoaPods to add the native modules to your project:

--- a/docs/appkit/react-native/wagmi/email.mdx
+++ b/docs/appkit/react-native/wagmi/email.mdx
@@ -3,8 +3,8 @@ import TabItem from '@theme/TabItem'
 
 ### Install packages
 
-```bash npm2yarn
-npm install @web3modal/email-wagmi-react-native react-native-webview
+```
+yarn add @web3modal/email-wagmi-react-native react-native-webview
 ```
 
 On iOS, use CocoaPods to add the native modules to your project:

--- a/docs/walletkit/react-native/installation.mdx
+++ b/docs/walletkit/react-native/installation.mdx
@@ -2,14 +2,14 @@
 
 Install WalletKit package.
 
-```bash npm2yarn
-npm install @walletconnect/web3wallet @walletconnect/react-native-compat
+```
+yarn add @walletconnect/web3wallet @walletconnect/react-native-compat
 ```
 
 Additionally add these extra packages to help with async storage, polyfills and the instance of ethers.
 
-```bash npm2yarn
-npm install @react-native-async-storage/async-storage @react-native-community/netinfo react-native-get-random-values fast-text-encoding
+```
+yarn add @react-native-async-storage/async-storage @react-native-community/netinfo react-native-get-random-values fast-text-encoding
 ```
 
 <details>
@@ -23,8 +23,8 @@ npx expo install expo-application
 
 For those using Typescript, we recommend adding these dev dependencies:
 
-```bash npm2yarn
-npm install --save-dev @walletconnect/jsonrpc-types
+```
+yarn add @walletconnect/jsonrpc-types --dev
 ```
 
 ## Next Steps

--- a/docs/walletkit/react-native/notifications/notify/installation.mdx
+++ b/docs/walletkit/react-native/notifications/notify/installation.mdx
@@ -5,8 +5,8 @@ import TabItem from '@theme/TabItem'
 
 Install the WalletConnect NotifyClient package.
 
-```bash npm2yarn
-npm install @walletconnect/notify-client @walletconnect/react-native-compat
+```
+yarn add @walletconnect/notify-client @walletconnect/react-native-compat
 ```
 
 You will need to polyfill crypto depending on your environment. See instructions below.
@@ -20,8 +20,8 @@ queryString="rn-method"
 >
 <TabItem value="expo">
 
-```bash npm2yarn
-npm i expo-crypto
+```
+yarn add expo-crypto
 ```
 
 1. Create a file called `expo-crypto-shim.js` at the root of your project
@@ -59,8 +59,8 @@ import './expo-crypto-shim.js'
 </TabItem>
 <TabItem value="rn-cli">
 
-```bash npm2yarn
-npm i react-native-quick-crypto react-native-quick-base64 stream-browserify @craftzdog/react-native-buffer babel-plugin-module-resolver
+```
+yarn add react-native-quick-crypto react-native-quick-base64 stream-browserify @craftzdog/react-native-buffer babel-plugin-module-resolver
 ```
 
 For iOS only

--- a/docs/walletkit/react-native/notifications/notify/usage.mdx
+++ b/docs/walletkit/react-native/notifications/notify/usage.mdx
@@ -274,8 +274,8 @@ export default function SubscriptionDetailsScreen() {
 Install [`@react-native-firebase/app`](https://www.npmjs.com/package/@react-native-firebase/app), [`@react-native-firebase/messaging`](https://www.npmjs.com/package/@react-native-firebase/messaging) and [`@notifee/react-native`](https://www.npmjs.com/package/@notifee/react-native) to handle Push Notifications.
 Please refer to the respective package documentation to configure them properly.
 
-```bash npm2yarn
-npm install @notifee/react-native @react-native-firebase/app @react-native-firebase/messaging
+```
+yarn add @notifee/react-native @react-native-firebase/app @react-native-firebase/messaging
 ```
 
 Update your `index.js` file to include the following logic.


### PR DESCRIPTION
### Summary
* Added extra step for universal wallets to config Cloud allowed mobile apps
* Removed npm2yarn plugin from react native docs