### PR TITLE
Revert "fix: update CSP"

### DIFF
--- a/docs/advanced/security/content-security-policy.md
+++ b/docs/advanced/security/content-security-policy.md
@@ -16,8 +16,8 @@ script-src 'self';
 style-src https://fonts.googleapis.com;
 img-src 'self' data: blob: https://walletconnect.org https://walletconnect.com https://secure.walletconnect.com https://secure.walletconnect.org https://tokens-data.1inch.io https://tokens.1inch.io https://ipfs.io;
 font-src 'self' https://fonts.gstatic.com;
-connect-src 'self' https://rpc.walletconnect.com https://rpc.walletconnect.org https://verify.walletconnect.com https://verify.walletconnect.org https://explorer-api.walletconnect.com https://explorer-api.walletconnect.org https://relay.walletconnect.com https://relay.walletconnect.org wss://relay.walletconnect.com wss://relay.walletconnect.org https://pulse.walletconnect.com https://pulse.walletconnect.org https://api.web3modal.com https://api.web3modal.org https://keys.walletconnect.com https://keys.walletconnect.org https://notify.walletconnect.com https://notify.walletconnect.org https://echo.walletconnect.com https://echo.walletconnect.org https://push.walletconnect.com https://push.walletconnect.org wss://www.walletlink.org;
-frame-src 'self' https://secure.walletconnect.com https://secure.walletconnect.org;
+connect-src 'self' https://rpc.walletconnect.com https://rpc.walletconnect.org https://explorer-api.walletconnect.com https://explorer-api.walletconnect.org https://relay.walletconnect.com https://relay.walletconnect.org wss://relay.walletconnect.com wss://relay.walletconnect.org https://pulse.walletconnect.com https://pulse.walletconnect.org https://api.web3modal.com https://api.web3modal.org https://keys.walletconnect.com https://keys.walletconnect.org https://notify.walletconnect.com https://notify.walletconnect.org https://echo.walletconnect.com https://echo.walletconnect.org https://push.walletconnect.com https://push.walletconnect.org wss://www.walletlink.org;
+frame-src 'self' https://verify.walletconnect.com https://verify.walletconnect.org https://secure.walletconnect.com https://secure.walletconnect.org;
 ```
 
 :::info


### PR DESCRIPTION
This reverts commit 4a73cc1056265b98c910401d011877dd9cfbca01.

This change was not necessary as Verify V2 was incompatible with best practice CSPs. Verify V3 takes a new approach which uses the same CSP values as before.