### PR TITLE
Added the wagmi `useDisconnect` import

### DIFF
--- a/docs/appkit/react/core/hooks.mdx
+++ b/docs/appkit/react/core/hooks.mdx
@@ -138,6 +138,8 @@ List of views you can select
 ## useDisconnect
 
 ```ts
+import { useDisconnect } from 'wagmi'
+
 const { disconnect } = useDisconnect()
 
 disconnect()


### PR DESCRIPTION
It is important to show developers that the hook comes from wagmi.