### PR TITLE
feat: Add EVM supported chains for social login

### DIFF
--- a/docs/appkit/features/socials.mdx
+++ b/docs/appkit/features/socials.mdx
@@ -17,6 +17,13 @@ AppKit supports the following providers:
 
 - **Email**, **Google**, **X**, **GitHub**, **Discord**, **Apple**, **Facebook** and **Farcaster**.
 
+## Supported Chains
+
+Our Email & Socials feature supports the following chains:
++ Algorand, Arbitrum, Astar zkEVM, Base, Berachain, Binance, Celo, Chiliz, Cronos, Etherlink, Fantom, Flare, Harmony, Hedera, Horizen EON, Loopring, Moonbeam, Near, Optimism, RARI Chain, Sei, ZetaChain, zkSync and XDC Network
+
+
+
 <Button name="Try Demo" url="https://lab.web3modal.com/library/wagmi/" />
 
 ## Get Started

--- a/docs/appkit/features/socials.mdx
+++ b/docs/appkit/features/socials.mdx
@@ -13,8 +13,9 @@ import flutterLogo from '../../../static/assets/home/flutterLogo.png'
 
 Bring your app to a world of new users in minutes with Email and Social login, giving both new and existing users the ability to seamlessly connect to your app using just an email address or social account. Set up with just one line of code and enable Smart Account functionality in minutes.
 
+<Button name="Try Demo" url="https://lab.web3modal.com/library/wagmi/" />
+## Supported Providers
 AppKit supports the following providers:
-
 - **Email**, **Google**, **X**, **GitHub**, **Discord**, **Apple**, **Facebook** and **Farcaster**.
 
 ## Supported Chains
@@ -22,9 +23,6 @@ AppKit supports the following providers:
 Our Email & Socials feature supports the following chains:
 + Algorand, Arbitrum, Astar zkEVM, Base, Berachain, Binance, Celo, Chiliz, Cronos, Etherlink, Fantom, Flare, Harmony, Hedera, Horizen EON, Loopring, Moonbeam, Near, Optimism, RARI Chain, Sei, ZetaChain, zkSync and XDC Network
 
-
-
-<Button name="Try Demo" url="https://lab.web3modal.com/library/wagmi/" />
 
 ## Get Started
 


### PR DESCRIPTION
Add only the EVM-supported chain for social logins.

Preview: https://walletconnect-docs-git-feat-add-social-lo-831ddf-walletconnect1.vercel.app/appkit/features/socials