### PR TITLE
docs update: Removing cautionary message for Solana v1

### DIFF
--- a/docs/appkit/features/solana.mdx
+++ b/docs/appkit/features/solana.mdx
@@ -18,11 +18,6 @@ import javascriptLogo from '../../../static/assets/home/javascriptLogo.png'
 
 The AppKit SDK supports Solana, allowing users to connect their Solana wallets to applications. AppKit provides a simple, secure, and seamless in-app experience for users looking to transact within web3.
 
-:::caution
-
-AppKit Solana is in canary and is not recommended for production use.
-:::
-
 <Button name="Try Demo" url="https://lab.web3modal.com/library/solana/" />
 
 ## Get Started

--- a/docs/appkit/javascript/core/installation.mdx
+++ b/docs/appkit/javascript/core/installation.mdx
@@ -53,11 +53,6 @@ npm install @web3modal/ethers ethers
 </PlatformTabItem>
 <PlatformTabItem value="solana">
 
-:::caution
-
-AppKit Solana is in canary and is not recommended for production use.
-:::
-
 ```bash npm2yarn
 npm install @web3modal/solana
 ```

--- a/docs/appkit/next/core/installation.mdx
+++ b/docs/appkit/next/core/installation.mdx
@@ -54,11 +54,6 @@ npm install @web3modal/ethers ethers
 </PlatformTabItem>
 <PlatformTabItem value="solana">
 
-:::caution
-
-AppKit Solana is in canary and is not recommended for production use.
-:::
-
 ```bash npm2yarn
 npm install @web3modal/solana
 ```

--- a/docs/appkit/react/core/installation.mdx
+++ b/docs/appkit/react/core/installation.mdx
@@ -51,11 +51,6 @@ npm install @web3modal/ethers ethers
 </PlatformTabItem>
 <PlatformTabItem value="solana">
 
-:::caution
-
-AppKit Solana is in canary and is not recommended for production use.
-:::
-
 ```bash npm2yarn
 npm install @web3modal/solana
 ```


### PR DESCRIPTION
## Description

`web3modal` supports Solana v1. All of the basic functionalities that Appkit provides works with Solana. This PR removes the cautionary messaging around Solana support and its installation. 

## Tests:

Docs tested locally 