### PR TITLE
Fix Typos and Grammar in Documentation

### DIFF
--- a/docs/advanced/multichain/rpc-reference/hedera-rpc.md
+++ b/docs/advanced/multichain/rpc-reference/hedera-rpc.md
@@ -55,7 +55,7 @@ In certain conditions, the Hedera network will return a response that signifies 
 
     1. `Object` - Result of transaction submission to Hedera network
       1.1. `code` : 9000 - The reserved WalletConnect error code for unknown errors or errors not related to the WalletConnect protocol
-      1.2. `message` : `String` - A human readable string describing the nature of the failure
+      1.2. `message` : `String` - A human-readable string describing the nature of the failure
       1.3. `data` : `Number` - An integer representing the ResponseCodeEnum value returned from the Hedera Node, which indicates the reason for the failure
 
 

--- a/docs/advanced/walletconnectmodal/about.mdx
+++ b/docs/advanced/walletconnectmodal/about.mdx
@@ -411,7 +411,7 @@ More wallet package names can be found in [our sample AndroidManifest.xml](https
 Wallet detection may produce inaccurate results on iOS Simulator. It is recommended to test on a real device.
 
 1. Make an iOS build.
-2. In the generated Xcode project, find `Info.plist` file and open it with a external editor (i.e. not Xcode).
+2. In the generated Xcode project, find `Info.plist` file and open it with an external editor (i.e. not Xcode).
 3. Locate or create `<key>LSApplicationQueriesSchemes</key>` section.
 4. Add the desired wallet schemes as string entries within the `<array>`. These schemes represent the wallets you want to detect.
 

--- a/docs/api/core/pairing.mdx
+++ b/docs/api/core/pairing.mdx
@@ -320,7 +320,7 @@ Now wallet and a dapp have a secure communication channel that will be used by t
 #### Pairing Dapp Usage
 
 In order to pair dapp and a wallet, dapp needs to generate and share an uri with wallet.
-To generate a uri call `create()` function on Pair instance as follows.
+To generate an uri call `create()` function on Pair instance as follows.
 
 ```swift
 let uri = try await Pair.instance.create()
@@ -337,7 +337,7 @@ Now you can share the uri with the wallet.
 val pairing: Pairing? = CoreClient.Pairing.create() { error -> }
 ```
 
-When first establishing a pairing with a Peer, call `CoreClient.Pairing.create`. This will try and generate a new pairing with a URI parameter that can be used to establish a connection with the other Peer as well as other meta data related to the pairing.
+When first establishing a pairing with a Peer, call `CoreClient.Pairing.create`. This will try and generate a new pairing with an URI parameter that can be used to establish a connection with the other Peer as well as other meta data related to the pairing.
 
 #
 
@@ -436,7 +436,7 @@ Now the wallet and a dapp have a secure communication channel that will be used 
 
 #### Pairing Dapp Usage
 
-In order to pair dapp and a wallet, dapp needs to generate and share a uri with wallet. To generate a uri call `create()` function on Pair instance as follows.
+In order to pair dapp and a wallet, dapp needs to generate and share an uri with wallet. To generate an uri call `create()` function on Pair instance as follows.
 
 ```csharp
 

--- a/docs/api/core/pairing.mdx
+++ b/docs/api/core/pairing.mdx
@@ -319,7 +319,7 @@ Now wallet and a dapp have a secure communication channel that will be used by t
 
 #### Pairing Dapp Usage
 
-In order to pair dapp and a wallet, dapp needs to generate and share a uri with wallet.
+In order to pair dapp and a wallet, dapp needs to generate and share an uri with wallet.
 To generate a uri call `create()` function on Pair instance as follows.
 
 ```swift

--- a/docs/appkit/javascript/notifications/cloud-setup.mdx
+++ b/docs/appkit/javascript/notifications/cloud-setup.mdx
@@ -15,7 +15,7 @@ It is important to understand what domain you are using for your project as you 
 
 You can pick 1 domain and this is configured in the Dapp URL field of the Notify API section of the [WalletConnect Cloud](https://cloud.walletconnect.com). You may change your domain at any time, as long as you properly host the new `did.json` file there. Note that only one project may use a given domain at the same time.
 
-During development it is optional to use your production domain for testing. Instead, you can use a staging domain, or even a entirely separate domain e.g. Vercel test site. However, once you move to production you will need to update your domain to your production domain and host a new file there.
+During development it is optional to use your production domain for testing. Instead, you can use a staging domain, or even an entirely separate domain e.g. Vercel test site. However, once you move to production you will need to update your domain to your production domain and host a new file there.
 
 Note that the file must be hosted on a real, publicly accessible, domain in order to verify its legitimacy. The use of `localhost` or other local addresses is not allowed.
 

--- a/docs/appkit/migration/from-anza-adapter-react.mdx
+++ b/docs/appkit/migration/from-anza-adapter-react.mdx
@@ -83,7 +83,7 @@ createWeb3Modal({
   })
 ```
 :::info
-Email an social logins are enabled by default.
+Email a social logins are enabled by default.
 :::
 
 

--- a/docs/appkit/react/notifications/cloud-setup.mdx
+++ b/docs/appkit/react/notifications/cloud-setup.mdx
@@ -15,7 +15,7 @@ It is important to understand what domain you are using for your project as you 
 
 You can pick 1 domain and this is configured in the Dapp URL field of the Notify API section of the [WalletConnect Cloud](https://cloud.walletconnect.com). You may change your domain at any time, as long as you properly host the new `did.json` file there. Note that only one project may use a given domain at the same time.
 
-During development it is optional to use your production domain for testing. Instead, you can use a staging domain, or even a entirely separate domain e.g. Vercel test site. However, once you move to production you will need to update your domain to your production domain and host a new file there.
+During development it is optional to use your production domain for testing. Instead, you can use a staging domain, or even an entirely separate domain e.g. Vercel test site. However, once you move to production you will need to update your domain to your production domain and host a new file there.
 
 Note that the file must be hosted on a real, publicly accessible, domain in order to verify its legitimacy. The use of `localhost` or other local addresses is not allowed.
 

--- a/docs/appkit/unity/core/options.mdx
+++ b/docs/appkit/unity/core/options.mdx
@@ -70,7 +70,7 @@ To enable Web3Modal to detect wallets installed on mobile devices, you need to m
     Wallet detection may produce inaccurate results on iOS Simulator. It is recommended to test on a real device.
 
     1. Make an iOS build.
-    2. In the generated Xcode project, find `Info.plist` file and open it with a external editor (i.e. not Xcode).
+    2. In the generated Xcode project, find `Info.plist` file and open it with an external editor (i.e. not Xcode).
     3. Locate or create `<key>LSApplicationQueriesSchemes</key>` section.
     4. Add the desired wallet schemes as string entries within the `<array>`. These schemes represent the wallets you want to detect.
 

--- a/docs/appkit/vue/notifications/cloud-setup.mdx
+++ b/docs/appkit/vue/notifications/cloud-setup.mdx
@@ -15,7 +15,7 @@ It is important to understand what domain you are using for your project as you 
 
 You can pick 1 domain and this is configured in the Dapp URL field of the Notify API section of the [WalletConnect Cloud](https://cloud.walletconnect.com). You may change your domain at any time, as long as you properly host the new `did.json` file there. Note that only one project may use a given domain at the same time.
 
-During development it is optional to use your production domain for testing. Instead, you can use a staging domain, or even a entirely separate domain e.g. Vercel test site. However, once you move to production you will need to update your domain to your production domain and host a new file there.
+During development it is optional to use your production domain for testing. Instead, you can use a staging domain, or even an entirely separate domain e.g. Vercel test site. However, once you move to production you will need to update your domain to your production domain and host a new file there.
 
 Note that the file must be hosted on a real, publicly accessible, domain in order to verify its legitimacy. The use of `localhost` or other local addresses is not allowed.
 


### PR DESCRIPTION
This PR corrects several typos and grammatical inconsistencies across the documentation. The key updates include:

- Standardizing the use of hyphenated terms, e.g., "human-readable."
- Correcting the use of articles ("a" vs. "an") for proper grammatical usage.
- Improving clarity and consistency in phrasing.

These changes enhance the readability and professionalism of the project documentation. Affected files include:

- `hedera-rpc.md`
- `about.mdx`
- `pairing.mdx`
- `cloud-setup.mdx`
- `from-anza-adapter-react.mdx`
- And more.
